### PR TITLE
Remove chef_requestor{} record from base_state{}.

### DIFF
--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -52,10 +52,6 @@
           %% Formatted using ~p, but expected to be reasonably small.
           log_msg = "" :: term(),
 
-          %% Set by chef_rest_wm:is_authorized to record whether
-          %% request is originating from a user or a client.
-          requester_type :: 'user' | 'client',
-
           %% Time drift in seconds allowed between the timestamp in a
           %% singed request and the clock on the server.  Set in
           %% app.config {chef_rest, auth_skey}.
@@ -83,8 +79,11 @@
           %% Opaque db connection context record as returned by chef_authz:make_context.
           chef_authz_context :: chef_authz:chef_authz_context(),
 
+          %% AuthzId for the actor making the request.
+          requestor_id :: object_id(),
+
           %% Details for The actor making the request.
-          requestor :: #chef_requestor{} | undefined,
+          requestor :: #chef_client{} | #chef_user{},
 
           %% A record containing resource-specific state.
           resource_state :: tuple(),

--- a/src/chef_wm_cookbook_version.erl
+++ b/src/chef_wm_cookbook_version.erl
@@ -140,10 +140,10 @@ from_json(Req, #base_state{resource_state = CookbookState} = State) ->
     end.
 
 delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 requestor_id = RequestorId,
                                  resource_state = #cookbook_state{
-                                     chef_cookbook_version = CookbookVersion},
-                                 requestor = #chef_requestor{
-                                     authz_id = RequestorId}} = State) ->
+                                     chef_cookbook_version = CookbookVersion}
+                                } = State) ->
     ok = ?BASE_RESOURCE:delete_object(DbContext, CookbookVersion, RequestorId),
     Json = chef_cookbook:assemble_cookbook_ejson(CookbookVersion),
     {true, chef_wm_util:set_json_body(Req, Json), State}.

--- a/src/chef_wm_named_client.erl
+++ b/src/chef_wm_named_client.erl
@@ -120,9 +120,9 @@ to_json(Req, #base_state{resource_state =
     {Json, Req, State}.
 
 delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 requestor_id = RequestorId,
                                  resource_state = #client_state{
                                    chef_client = Client},
-                                 requestor = #chef_requestor{authz_id = RequestorId},
                                  organization_name = OrgName} = State) ->
     ok = chef_object_db:delete(DbContext, Client, RequestorId),
     EJson = chef_client:assemble_client_ejson(Client, OrgName),

--- a/src/chef_wm_named_data.erl
+++ b/src/chef_wm_named_data.erl
@@ -117,12 +117,11 @@ create_path(Req, #base_state{resource_state = #data_state{
     {binary_to_list(ItemName), Req, State}.
 
 from_json(Req, #base_state{chef_db_context = DbContext,
+                           requestor_id = ActorId,
                            resource_state = #data_state{data_bag_name = DataBagName,
                                                         data_bag_item_name = ItemName,
                                                         data_bag_item_ejson = ItemData},
                            organization_guid = OrgId,
-                           requestor = #chef_requestor{authz_id = ActorId},
-                           %reqid = _ReqId,
                            db_type = DbType} = State) ->
 
     %% Note: potential race condition.  If we don't have perms, the create will fail.
@@ -181,11 +180,11 @@ to_json(Req, State) ->
     {items_for_data_bag(Req, State), Req, State}.
 
 delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 requestor_id = RequestorId,
                                  resource_state = #data_state{
                                      chef_data_bag = DataBag,
-                                     data_bag_name = DataBagName},
-                                 requestor = #chef_requestor{
-                                     authz_id = RequestorId}} = State) ->
+                                     data_bag_name = DataBagName}
+                                } = State) ->
 
     ok = chef_object_db:delete(DbContext, DataBag, RequestorId),
     NakedBag = {[{<<"name">>, DataBagName},

--- a/src/chef_wm_named_data_item.erl
+++ b/src/chef_wm_named_data_item.erl
@@ -132,12 +132,12 @@ to_json(Req, #base_state{resource_state = DataBagState} = State) ->
     {chef_db_compression:decompress(JSON), Req, State}.
 
 delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 requestor_id = RequestorId,
                                  resource_state = #data_state{
                                      data_bag_name = BagName,
                                      data_bag_item_name = ItemName,
-                                     chef_data_bag_item = Item},
-                                 requestor = #chef_requestor{
-                                     authz_id = RequestorId}}=State) ->
+                                     chef_data_bag_item = Item}
+                                }=State) ->
 
     ok = chef_object_db:delete(DbContext, Item, RequestorId),
     Json = chef_db_compression:decompress(Item#chef_data_bag_item.serialized_object),

--- a/src/chef_wm_named_environment.erl
+++ b/src/chef_wm_named_environment.erl
@@ -94,10 +94,10 @@ from_json(Req, #base_state{resource_state =
     chef_wm_base:update_from_json(Req, State, Environment, EnvironmentData).
 
 delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 requestor_id = RequestorId,
                                  resource_state = #environment_state{
-                                     chef_environment = Environment},
-                                 requestor = #chef_requestor{
-                                     authz_id = RequestorId}} = State) ->
+                                     chef_environment = Environment}
+                                } = State) ->
 
     ok = ?BASE_RESOURCE:delete_object(DbContext, Environment, RequestorId),
     Json = chef_db_compression:decompress(Environment#chef_environment.serialized_object),

--- a/src/chef_wm_named_node.erl
+++ b/src/chef_wm_named_node.erl
@@ -78,10 +78,10 @@ from_json(Req, #base_state{resource_state = #node_state{chef_node = Node,
     chef_wm_base:update_from_json(Req, State, Node, NodeData).
 
 delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 requestor_id = RequestorId,
                                  resource_state = #node_state{
-                                     chef_node = Node},
-                                 requestor = #chef_requestor{
-                                     authz_id = RequestorId}} = State) ->
+                                     chef_node = Node}
+                                } = State) ->
 
     ok = ?BASE_RESOURCE:delete_object(DbContext, Node, RequestorId),
     Json = chef_db_compression:decompress(Node#chef_node.serialized_object),

--- a/src/chef_wm_named_role.erl
+++ b/src/chef_wm_named_role.erl
@@ -87,10 +87,10 @@ from_json(Req, #base_state{resource_state = #role_state{chef_role = Role,
     chef_wm_base:update_from_json(Req, State, Role, RoleData).
 
 delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 requestor_id = RequestorId,
                                  resource_state = #role_state{
-                                     chef_role = Role},
-                                 requestor = #chef_requestor{
-                                     authz_id = RequestorId}} = State) ->
+                                     chef_role = Role}
+                                } = State) ->
 
     ok = ?BASE_RESOURCE:delete_object(DbContext, Role, RequestorId),
 

--- a/src/chef_wm_sandboxes.erl
+++ b/src/chef_wm_sandboxes.erl
@@ -78,8 +78,8 @@ create_path(Req, #base_state{organization_guid = OrgId,
     {binary_to_list(Id), Req, State#base_state{resource_state = SandboxState1}}.
 
 from_json(Req, #base_state{chef_db_context = DbContext,
+                           requestor_id = ActorId,
                            organization_name = OrgName,
-                           requestor = #chef_requestor{authz_id = ActorId},
                            resource_state =
                                #sandbox_state{sandbox_data = SandboxData}} = State) ->
     Checksums = checksums_from_sandbox_ejson(SandboxData),


### PR DESCRIPTION
Replace it with the requestor_id (AuthzId) and the actual
chef_client{} or chef_user{} which is making the request.

These can now be used directly for authz decisions
