### PR TITLE
Remove DbType arg from calls into chef_object and chef_db_compression

### DIFF
--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -88,9 +88,6 @@
           %% A record containing resource-specific state.
           resource_state :: tuple(),
 
-          %% Type of database backend we are talking to
-          db_type :: 'mysql' | 'pgsql',
-
           %% Turn this on if superuser is allowed to bypass security checks for
           %% this endpoint.
           superuser_bypasses_checks = false :: true | false

--- a/src/chef_sked.erl
+++ b/src/chef_sked.erl
@@ -14,8 +14,7 @@
 -include_lib("chef_certgen/include/chef_certgen.hrl").
 
 -export([create_client/4,
-         create_default_environment/0,
-         create_default_environment/1]).
+         create_default_environment/0]).
 
 %% An authz id used as the requestor id for operations performed by
 %% this helper module.
@@ -50,20 +49,15 @@ create_client(Name, IsValidator, IsAdmin, PublicKey) ->
     Ctx = chef_db:make_context(make_req_id()),
     chef_db:create_client(Ctx, Client, ?CHEF_SKED_AUTHZ_ID).
 
-%% @doc Create the _default environment assuming the default RDBMS of PostgreSQL.
+%% @doc Create the _default environment
 create_default_environment() ->
-    create_default_environment(pgsql).
-
-%% @doc Create the _default environment with compression determined by
-%% `DbType'.
-create_default_environment(DbType) ->
     Name = <<"_default">>,
     Json = <<"{\"name\":\"_default\",\"description\":\"The default Chef environment\","
              "\"cookbook_versions\":{},\"json_class\":\"Chef::Environment\","
              "\"chef_type\":\"environment\","
              "\"default_attributes\":{},"
              "\"override_attributes\":{}}">>,
-    Data = chef_db_compression:compress(DbType, chef_environment, Json),
+    Data = chef_db_compression:compress(chef_environment, Json),
     Id = chef_object:make_org_prefix_id(?OSC_ORG_ID, Name),
     Env = #chef_environment{id = Id,
                             authz_id = Id,

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -62,7 +62,6 @@ init_base_state(ResourceMod, InitParams) ->
     #base_state{reqid_header_name = ?gv(reqid_header_name, InitParams),
                 batch_size = ?gv(batch_size, InitParams),
                 auth_skew = ?gv(auth_skew, InitParams),
-                db_type = ?gv(db_type, InitParams),
                 resource_mod = ResourceMod}.
 
 %% @doc Determines if service is available.
@@ -303,13 +302,11 @@ verify_request_signature(Req,
 create_from_json(#wm_reqdata{} = Req,
                  #base_state{chef_db_context = DbContext,
                              organization_guid = OrgId,
-                             requestor_id = ActorId,
-                             db_type = DbType} = State,
+                             requestor_id = ActorId} = State,
                  RecType, {authz_id, AuthzId}, ObjectEjson) ->
     %% ObjectEjson should already be normalized. Record creation does minimal work and does
     %% not add or update any fields.
-    ObjectRec = chef_object:new_record(RecType, OrgId, maybe_authz_id(AuthzId), ObjectEjson,
-                                       DbType),
+    ObjectRec = chef_object:new_record(RecType, OrgId, maybe_authz_id(AuthzId), ObjectEjson),
     Id = chef_object:id(ObjectRec),
     Name = chef_object:name(ObjectRec),
     TypeName = chef_object:type_name(ObjectRec),
@@ -350,9 +347,9 @@ create_from_json(#wm_reqdata{} = Req,
 %% record. `ObjectEjson' is the parsed EJSON from the request body.
 update_from_json(#wm_reqdata{} = Req, #base_state{chef_db_context = DbContext,
                                                   organization_guid = OrgId,
-                                                  requestor_id = ActorId,
-                                                  db_type = DbType}=State, OrigObjectRec, ObjectEjson) ->
-    ObjectRec = chef_object:update_from_ejson(OrigObjectRec, ObjectEjson, DbType),
+                                                  requestor_id = ActorId}=State,
+                 OrigObjectRec, ObjectEjson) ->
+    ObjectRec = chef_object:update_from_ejson(OrigObjectRec, ObjectEjson),
     %% Send object to solr for indexing *first*. If the update fails, we will have sent
     %% incorrect data, but that should get corrected when the client retries. This is a
     %% compromise.

--- a/src/chef_wm_named_data.erl
+++ b/src/chef_wm_named_data.erl
@@ -121,8 +121,7 @@ from_json(Req, #base_state{chef_db_context = DbContext,
                            resource_state = #data_state{data_bag_name = DataBagName,
                                                         data_bag_item_name = ItemName,
                                                         data_bag_item_ejson = ItemData},
-                           organization_guid = OrgId,
-                           db_type = DbType} = State) ->
+                           organization_guid = OrgId} = State) ->
 
     %% Note: potential race condition.  If we don't have perms, the create will fail.
     %% Although we checked rights above, they could have changed.
@@ -130,7 +129,7 @@ from_json(Req, #base_state{chef_db_context = DbContext,
     %% the 'unset' atom is where an AuthzId would typically go. Since chef_data_bag_item
     %% objects do not have their own AuthzId, we hard-code the placeholder.
     DataBagItem = chef_object:new_record(chef_data_bag_item, OrgId, unset,
-                                         {DataBagName, ItemData}, DbType),
+                                         {DataBagName, ItemData}),
     %% We send the data_bag_item data to solr for indexing *first*. If it fails, we'll error out on a
     %% 500 and client can retry. If we succeed and the db call fails or conflicts, we can
     %% safely send a delete to solr since this is a new data_bag_item with a unique ID unknown to the

--- a/src/chef_wm_sup.erl
+++ b/src/chef_wm_sup.erl
@@ -143,7 +143,6 @@ fetch_custom_init_params(Module, Defaults) ->
 default_resource_init() ->
     Defaults = [{batch_size, get_env(chef_wm, bulk_fetch_batch_size)},
                 {auth_skew, get_env(chef_wm, auth_skew)},
-                {db_type, get_env(sqerl, db_type)},
                 {reqid_header_name, get_env(chef_wm, reqid_header_name)}],
     case application:get_env(chef_wm, request_tracing) of
         {ok, true} ->


### PR DESCRIPTION
Depends on remove-db-type branch in chef_objects being merged and for OSC erchef the schema having a serialized_object column in the node table of type bytea with storage external.

You can test with the current pgsql uncompressed node schema by setting a compiler define for a clean build -- see the chef_object repo for details.
