### PR TITLE
Jc/oc 3105/forbidden by default

### DIFF
--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -728,8 +728,7 @@ handle_auth_info(chef_wm_named_node, Req, #base_state{requestor = Requestor}) ->
         _Else ->
             forbidden
     end;
-handle_auth_info(Module, Req, #base_state{requestor = Requestor})
-        when Module =:= chef_wm_nodes ->
+handle_auth_info(chef_wm_nodes, Req, _State) ->
     case wrq:method(Req) of
         'GET' ->
             authorized;
@@ -770,7 +769,7 @@ handle_auth_info(Module, Req, _State)
             forbidden
     end;
 %% Default case is to allow disallow all requests
-handle_auth_info(Mod, Req, _State) ->
+handle_auth_info(_Mod, _Req, _State) ->
     forbidden.
 
 set_forbidden_msg(Req, State) ->

--- a/test/chef_wm_authz_tests.erl
+++ b/test/chef_wm_authz_tests.erl
@@ -33,16 +33,16 @@ allow_admin_test_() ->
      fun() -> ?assertError(function_clause, chef_wm_authz:allow_admin(#chef_node{name= <<"foo">>})) end}
     ].
 
-is_validator_test_() ->
+allow_validator_test_() ->
   [
-    {"is_validator Admin is false",
-     fun() -> ?assertEqual(forbidden, chef_wm_authz:is_validator(?ADMIN)) end},
-    {"is_validator Validator is true",
-     fun() -> ?assertEqual(authorized, chef_wm_authz:is_validator(?VALIDATOR)) end},
-    {"is_validator non-admin is false",
-     fun() -> ?assertEqual(forbidden, chef_wm_authz:is_validator(?NONADMIN)) end},
-    {"no match for is_validator with non-client",
-     fun() -> ?assertError(function_clause, chef_wm_authz:is_validator(#chef_node{name= <<"foo">>})) end}
+    {"allow_validator Admin is false",
+     fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_validator(?ADMIN)) end},
+    {"allow_validator Validator is true",
+     fun() -> ?assertEqual(authorized, chef_wm_authz:allow_validator(?VALIDATOR)) end},
+    {"allow_validator non-admin is false",
+     fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_validator(?NONADMIN)) end},
+    {"no match for allow_validator with non-client",
+     fun() -> ?assertError(function_clause, chef_wm_authz:allow_validator(#chef_node{name= <<"foo">>})) end}
     ].
 
 allow_admin_or_validator_test_() ->


### PR DESCRIPTION
Make OSC authz be forbidden by default for all endpoints and methods

An explicit implementation is needed in chef_wm_base:handle_auth_info/3 for each new endpoint
