### PR TITLE
GET /sandboxes is not supported

### DIFF
--- a/src/chef_wm_sandboxes.erl
+++ b/src/chef_wm_sandboxes.erl
@@ -43,10 +43,8 @@ request_type() ->
     "sandboxes".
 
 allowed_methods(Req, State) ->
-    {['GET','POST'], Req, State}.
+    {['POST'], Req, State}.
 
-validate_request('GET', Req, State) ->
-    {Req, State};
 validate_request('POST', Req, #base_state{resource_state = BoxState} = State) ->
     {ok, Sandbox} = chef_sandbox:parse_binary_json(wrq:req_body(Req), create),
     {Req, State#base_state{resource_state = BoxState#sandbox_state{sandbox_data = Sandbox}}}.
@@ -55,19 +53,10 @@ auth_info(Req, State) ->
     auth_info(wrq:method(Req), Req, State).
 
 auth_info('POST', Req, State) ->
-    {{create_in_container, sandbox}, Req, State};
-auth_info('GET', Req, State) ->
-    {{container, sandbox}, Req, State}.
+    {{create_in_container, sandbox}, Req, State}.
 
-resource_exists(Req, #base_state{organization_name = OrgName} = State) ->
-    case wrq:method(Req) of
-        'GET' ->
-            Msg = chef_wm_util:not_found_message(sandboxes, OrgName),
-            Req1 = chef_wm_util:set_json_body(Req, Msg),
-            {false, Req1, State};
-        _ ->
-            {true, Req, State}
-    end.
+resource_exists(Req, State) ->
+    {true, Req, State}.
 
 create_path(Req, #base_state{organization_guid = OrgId,
                              resource_state = SandboxState}=State) ->

--- a/src/chef_wm_sandboxes.erl
+++ b/src/chef_wm_sandboxes.erl
@@ -29,8 +29,7 @@
 -export([
          allowed_methods/2,
          create_path/2,
-         from_json/2,
-         resource_exists/2
+         from_json/2
         ]).
 
 init(Config) ->
@@ -54,9 +53,6 @@ auth_info(Req, State) ->
 
 auth_info('POST', Req, State) ->
     {{create_in_container, sandbox}, Req, State}.
-
-resource_exists(Req, State) ->
-    {true, Req, State}.
 
 create_path(Req, #base_state{organization_guid = OrgId,
                              resource_state = SandboxState}=State) ->

--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -90,8 +90,6 @@ not_found_message(data_bag_missing_for_item_post, BagName) ->
                                              BagName,
                                              "' could be found. Please create this ",
                                              "data bag before adding items to it."]));
-not_found_message(sandboxes, _OrgName) ->
-    error_message_envelope(<<"Listing sandboxes not supported.">>);
 not_found_message(sandbox, SandboxId) ->
     error_message_envelope(iolist_to_binary([<<"No such sandbox '">>, SandboxId,
                                              <<"'.">>]));


### PR DESCRIPTION
We were returning a 404 and a message to the effect that listing sandboxes is not allowed.  This was an unwitting perpetuation of  bad Merb behavior from the old Ruby implementation.  Now, we return 405 instead.
