### PR TITLE
Role environments

### DIFF
--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -161,6 +161,7 @@
          }).
 
 -record(role_state, {
+          env_run_list_only = false :: boolean(),
           %% EJson-encoded representation of a Role
           role_data,
           role_authz_id,

--- a/priv/dispatch.conf
+++ b/priv/dispatch.conf
@@ -34,16 +34,11 @@
 
 {["environments"], chef_wm_environments, []}.
 {["environments", environment_name], chef_wm_named_environment, []}.
-{["environments", environment_name, "cookbook_versions"],
- chef_wm_depsolver, []}.
-{["environments", environment_name, "nodes"],
- chef_wm_nodes, []}.
-{["environments", environment_name, "roles", role_name],
- chef_wm_environment_roles, []}.
-{["environments", environment_name, "recipes"],
- chef_wm_environment_recipes, []}.
-{["environments", environment_name, "cookbooks"],
- chef_wm_environment_cookbooks, []}.
+{["environments", environment_name, "cookbook_versions"], chef_wm_depsolver, []}.
+{["environments", environment_name, "nodes"], chef_wm_nodes, []}.
+{["environments", environment_name, "roles", role_name], chef_wm_environment_roles, []}.
+{["environments", environment_name, "recipes"], chef_wm_environment_recipes, []}.
+{["environments", environment_name, "cookbooks"], chef_wm_environment_cookbooks, []}.
 {["environments", environment_name, "cookbooks", cookbook_name],
  chef_wm_environment_cookbooks, []}.
 

--- a/priv/dispatch.conf
+++ b/priv/dispatch.conf
@@ -47,6 +47,7 @@
 
 {["roles"], chef_wm_roles, []}.
 {["roles", role_name], chef_wm_named_role, []}.
+{["roles", role_name, "environments"], chef_wm_named_role, [{env_run_list_only, true}]}.
 {["roles", role_name, "environments", environment_name],
  chef_wm_environment_roles, []}.
 

--- a/src/chef_wm_named_role.erl
+++ b/src/chef_wm_named_role.erl
@@ -55,6 +55,10 @@ init(Config) ->
     chef_wm_base:init(?MODULE, Config).
 
 init_resource_state(Config) ->
+    %% this resource serves named roles as well as the /roles/:role/environments endpoint
+    %% that returns just the names of the environments that a given role has
+    %% environment-specific run lists for. The behavior is determined by the value of init
+    %% parameter 'env_run_list_only'.
     EnvRunListOnly = (true =:= proplists:get_value(env_run_list_only, Config)),
     {ok, #role_state{env_run_list_only = EnvRunListOnly}}.
 


### PR DESCRIPTION
Add support for /roles/:role/environments that returns the names of the keys in the env_run_lists hash of the specified role.
