### PR TITLE
assemble[_minimal]_cookbook_ejson methods now always

### DIFF
--- a/src/chef_wm_depsolver.erl
+++ b/src/chef_wm_depsolver.erl
@@ -272,7 +272,7 @@ assemble_response(Req, State, CookbookVersions) ->
             %% cookbook which has just enough information for chef-client to run
             JsonList = {
                     [ { CBV#chef_cookbook_version.name,
-                       chef_cookbook:minimal_cookbook_ejson_with_s3urls(CBV) }
+                       chef_cookbook:minimal_cookbook_ejson(CBV) }
                       || CBV <- CookbookVersions ]
                     },
             CBMapJson = ejson:encode(JsonList),


### PR DESCRIPTION
return URLs to S3/bookshelf.  Remove extra _with_s3 methods
