### PR TITLE
Standardize on ej:valid validation

### DIFF
--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -120,15 +120,15 @@ malformed_request(Req, #base_state{resource_mod=Mod,
             Req3 = wrq:set_resp_body(chef_json:encode({[{<<"error">>, [Msg]}]}), Req),
             {{halt, 404}, Req3, State1#base_state{log_msg = org_not_found}};
         throw:bad_clock ->
-            Msg1 = malformed_request_message(bad_clock, Req, State),
+            Msg1 = chef_wm_malformed:malformed_request_message(bad_clock, Req, State),
             Req3 = wrq:set_resp_body(chef_json:encode(Msg1), Req),
             {{halt, 401}, Req3, State1#base_state{log_msg = bad_clock}};
                 throw:bad_headers ->
-            Msg1 = malformed_request_message(bad_headers, Req, State),
+            Msg1 =  chef_wm_malformed:malformed_request_message(bad_headers, Req, State),
             Req3 = wrq:set_resp_body(chef_json:encode(Msg1), Req),
             {{halt, 401}, Req3, State1#base_state{log_msg = bad_headers}};
         throw:bad_sign_desc ->
-            Msg1 = malformed_request_message(bad_sign_desc, Req, State),
+            Msg1 =  chef_wm_malformed:malformed_request_message(bad_sign_desc, Req, State),
             Req3 = wrq:set_resp_body(chef_json:encode(Msg1), Req),
             {{halt, 400}, Req3, State1#base_state{log_msg = bad_sign_desc}};
         throw:{too_big, Msg} ->
@@ -136,180 +136,10 @@ malformed_request(Req, #base_state{resource_mod=Mod,
             Req3 = wrq:set_resp_body(chef_json:encode({[{<<"error">>, Msg}]}), Req),
             {{halt, 413}, Req3, State1#base_state{log_msg = too_big}};
         throw:Why ->
-            Msg = malformed_request_message(Why, Req, State),
+            Msg =  chef_wm_malformed:malformed_request_message(Why, Req, State),
             NewReq = wrq:set_resp_body(chef_json:encode(Msg), Req),
             {true, NewReq, State1#base_state{log_msg = Why}}
     end.
-
-
-%% @doc Handle common malformed request tasks with resource-specific callbacks
-%%
-%% This function does a sanity check on the authn headers (not verifying signing, but does
-%% all checks it can without talking to a db).  It also checks for org existence and halts
-%% with 404 if the org is not found.  This doesn't strictly belong in malformed_request, but
-%% right now all of our resources need this check and end up needing it before
-%% resource_exists will get called so we do it here.
-%%
-%% The caller provides `ValidateFun' which will be given `Req' and `State' as args and
-%% should return a `{Req, State}' tuple or throw.  The `ErrorMsgFun' will be called as
-%% `ErrorMsgFun(Reason, Req, State)' where `Reason' is the term thrown by `ValidateFun'.
-%%
-
-malformed_request_message(bad_clock, Req, State) ->
-    {GetHeader, _State1} = chef_wm_util:get_header_fun(Req, State),
-    User = case GetHeader(<<"X-Ops-UserId">>) of
-               undefined -> <<"">>;
-               UID -> UID
-           end,
-    Msg = iolist_to_binary([<<"Failed to authenticate as ">>, User,
-                            <<". Synchronize the clock on your host.">>]),
-    {[{<<"error">>, [Msg]}]};
-malformed_request_message(bad_sign_desc, _Req, _State) ->
-    Msg = <<"Unsupported authentication protocol version">>,
-    {[{<<"error">>, [Msg]}]};
-malformed_request_message({missing_headers, Missing}, _Req, _State) ->
-    Msg = iolist_to_binary([
-                            <<"missing required authentication header(s) ">>,
-                            bin_str_join(Missing, <<", ">>)]),
-    {[{<<"error">>, [Msg]}]};
-malformed_request_message({bad_headers, Bad}, _Req, _State) ->
-    Msg = iolist_to_binary([
-                            <<"bad header(s) ">>,
-                            bin_str_join(Bad, <<", ">>)]),
-    {[{<<"error">>, [Msg]}]};
-malformed_request_message({error, invalid_json}, _Req, _State) ->
-    %% in theory, there might be some sort of slightly useful error detail from
-    %% chef_json/jiffy, but thus far nothing specific enough to beat out this. Also, would
-    %% not passing internal library error messages out to the user when possible.
-    {[{<<"error">>, [<<"invalid JSON">>]}]};
-malformed_request_message({mismatch, {FieldName, _Pat, _Val}}, _Req, _State) ->
-    {[{<<"error">>, [iolist_to_binary(["Field '", FieldName, "' invalid"])]}]};
-malformed_request_message({missing, FieldName}, _Req, _State) ->
-    {[{<<"error">>, [iolist_to_binary(["Field '", FieldName, "' missing"])]}]};
-malformed_request_message({both_missing, Field1, _Field2}, _Req, _State) ->
-    {[{<<"error">>, [iolist_to_binary(["Field '", Field1, "' missing"])]}]};
-malformed_request_message({client_name_mismatch}, _Req, _State) ->
-    {[{<<"error">>, [<<"name and clientname must match">>]}]};
-malformed_request_message({bad_client_name, Name, Pattern}, _Req, _State) ->
-    {[{<<"error">>, [iolist_to_binary(["Invalid client name '", Name,
-                                       "' using regex: '", Pattern, "'."])]}]};
-
-%% Not sure if we want to be this specific, or just want to fold this into an 'invalid JSON'
-%% case.  At any rate, here it is.
-malformed_request_message({bad_string_list, {Field, _Value}}, _Req, _State) ->
-    {[{<<"error">>, [iolist_to_binary(["Field '", Field, "' is not a list of strings"])]}]};
-malformed_request_message({bad_ejson_proplist, {Field, _Value}}, _Req, _State) ->
-    {[{<<"error">>, [iolist_to_binary(["Field '", Field, "' is not a hash"])]}]};
-malformed_request_message({url_json_name_mismatch, {_UrlName, _Mismatch, Type}}, _Req, _State) ->
-    {[{<<"error">>, [iolist_to_binary([Type, <<" name mismatch.">>])]}]};
-malformed_request_message({bad_run_list, {Field, _Value}}, _Req, _State) ->
-    {[{<<"error">>, [iolist_to_binary(["Field '", Field, "' is not a valid run list"])]}]};
-malformed_request_message({bad_run_lists, {Field, _Value}}, _Req, _State) ->
-    {[{<<"error">>, [iolist_to_binary(["Field '", Field, "' contains invalid run lists"])]}]};
-malformed_request_message(invalid_num_versions, _Req, _State) ->
-    {[{<<"error">>, [<<"You have requested an invalid number of versions (x >= 0 || 'all')">>]}]};
-
-%% This is used by some custom validation in environments that may (or may not!) be pulled up into ej:valid validations
-malformed_request_message({invalid_key, Key}, _Req, _State) ->
-    error_envelope([<<"Invalid key ">>, Key, <<" in request body">>]);
-
-malformed_request_message(invalid_json_body, _Req, _State) ->
-    error_envelope([<<"Incorrect JSON type for request body">>]);
-
-%% General ej_invalid messages
-
-%% Missing fields
-malformed_request_message(#ej_invalid{type=missing,
-                                      key=Key
-                                     }, _Req, _State) ->
-    error_envelope([<<"Field '", Key/binary, "' missing">>]);
-
-%% Exact and string_match failures
-malformed_request_message(#ej_invalid{type=Type,
-                                      key=Key,
-                                      msg=Expected
-                                     }, _Req, _State) when Type =:= exact ;
-                                                           Type =:= string_match ->
-    error_envelope([<<"Field '", Key/binary, "' invalid">>]);
-
-%% Things that should be hashes, but aren't.
-malformed_request_message(#ej_invalid{type=json_type,
-                                      key=Key
-                                     }, _Req, _State) when Key =:= <<"override_attributes">> ;
-                                                           Key =:= <<"default_attributes">> ;
-                                                           Key =:= <<"normal">> ;
-                                                           Key =:= <<"default">> ;
-                                                           Key =:= <<"override">> ;
-                                                           Key =:= <<"automatic">> ;
-                                                           Key =:= <<"cookbook_versions">> ->
-    error_envelope([<<"Field '", Key/binary, "' is not a hash">>]);
-
-%% Entire run list is the wrong type
-malformed_request_message(#ej_invalid{type=json_type,
-                                     key=Key}, _Req, _State) when Key =:= <<"run_list">> ->
-    error_envelope([<<"Field '", Key/binary,"' is not a valid run list">>]);
-
-%% entire env_run_lists is the wrong type
-malformed_request_message(#ej_invalid{type=json_type,
-                                      key=Key
-                                     }, _Req, _State) when Key =:= <<"env_run_lists">> ->
-    error_envelope([<<"Field '", Key/binary, "' contains invalid run lists">>]);
-
-%% All other json_type failures
-malformed_request_message(#ej_invalid{type=json_type,
-                                      key=Key
-                                     }, _Req, _State) ->
-    error_envelope([<<"Field '", Key/binary, "' invalid">>]);
-
-%% Bogus run list items
-%%
-%% In the future, we may wish to add more detailed error messages reflecting whether a run
-%% list item is simply the wrong type (e.g., a number) or an invalid run list item (e.g.,
-%% the string "recipe[").  To do so, we would need to compare the `found_type` and
-%% `expected_type` record fields
-malformed_request_message(#ej_invalid{type=array_elt,
-                                      key=Key}, _Req, _State) when Key =:= <<"run_list">> ->
-    error_envelope([<<"Field '", Key/binary, "' is not a valid run list">>]);
-
-malformed_request_message(#ej_invalid{type = object_key,
-                                      key = Object,
-                                      found = Key}, _Req, _State) ->
-    error_envelope([<<"Invalid key '">>, Key, <<"' for ">>, Object]);
-
-malformed_request_message(#ej_invalid{type = object_value,
-                                      key = Key,
-                                      found = Val}, _Req, _State) when Key =:= <<"env_run_lists">> ->
-    error_envelope([<<"Field '", Key/binary, "' contains invalid run lists">>]);
-
-malformed_request_message(#ej_invalid{type = object_value,
-                                      key = Object,
-                                      found = Val}, _Req, _State) ->
-    error_envelope([<<"Invalid value '">>, Val, <<"' for ">>, Object]);
-
-
-malformed_request_message(Reason, Req, #base_state{resource_mod=Mod}=State) ->
-    Mod:malformed_request_message(Reason, Req, State).
-
--spec to_binary( any() ) -> binary().
-to_binary(A) when is_atom(A) ->
-    atom_to_binary(A, utf8);
-to_binary(I) when is_integer(I)->
-    list_to_binary(integer_to_list(I));
-to_binary(B) when is_binary(B)->
-    B;
-to_binary(O) ->
-    %% Catch-all case
-    list_to_binary(io_lib:format("~p", [O])).
-
--spec binary_message([atom() | string() | binary()]) -> binary().
-binary_message(Parts)  ->
-    iolist_to_binary([to_binary(P) || P <- Parts]).
-
--spec error_envelope(binary() | [binary()]) -> ej:json_object().
-error_envelope(Parts) when is_list(Parts) ->
-    error_envelope(binary_message(Parts));
-error_envelope(Message) when is_binary(Message) ->
-    chef_wm_util:error_message_envelope(Message).
 
 forbidden(Req, #base_state{resource_mod=Mod}=State) ->
     %% For now we call auth_info because currently need the side-effect of looking up the
@@ -635,14 +465,6 @@ log_level(Code) when Code >= 500 ->
     err;
 log_level(_) ->
     info.
-
-bin_str_join(L, Sep) ->
-    bin_str_join(L, Sep, []).
-
-bin_str_join([H], _Sep, Acc) ->
-    lists:reverse([<<"'">>, H, <<"'">>|Acc]);
-bin_str_join([H | T], Sep, Acc) ->
-    bin_str_join(T, Sep, [Sep, <<"'">>, H, <<"'">> | Acc]).
 
 fetch_org_guid(#base_state{organization_guid = Id}) when is_binary(Id) ->
     Id;

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -228,19 +228,19 @@ malformed_request_message(#ej_invalid{type=missing,
 malformed_request_message(#ej_invalid{type=Type,
                                       key=Key,
                                       msg=Expected
-                                     }, _Req, _State) when Type =:= exact orelse
+                                     }, _Req, _State) when Type =:= exact ;
                                                            Type =:= string_match ->
     error_envelope([<<"Field '", Key/binary, "' invalid">>]);
 
 %% Things that should be hashes, but aren't.
 malformed_request_message(#ej_invalid{type=json_type,
                                       key=Key
-                                     }, _Req, _State) when Key =:= <<"override_attributes">> orelse
-                                                           Key =:= <<"default_attributes">> orelse
-                                                           Key =:= <<"normal">> orelse
-                                                           Key =:= <<"default">> orelse
-                                                           Key =:= <<"override">> orelse
-                                                           Key =:= <<"automatic">> orelse
+                                     }, _Req, _State) when Key =:= <<"override_attributes">> ;
+                                                           Key =:= <<"default_attributes">> ;
+                                                           Key =:= <<"normal">> ;
+                                                           Key =:= <<"default">> ;
+                                                           Key =:= <<"override">> ;
+                                                           Key =:= <<"automatic">> ;
                                                            Key =:= <<"cookbook_versions">> ->
     error_envelope([<<"Field '", Key/binary, "' is not a hash">>]);
 

--- a/src/chef_wm_clients.erl
+++ b/src/chef_wm_clients.erl
@@ -138,4 +138,4 @@ all_clients_json(Req, #base_state{chef_db_context = DbContext,
     chef_json:encode({UriMap}).
 
 malformed_request_message(Any, Req, State) ->
-    chef_wm_util:malformed_request_message(Any, Req, State).
+    chef_wm_malformed:malformed_request_message(Any, Req, State).

--- a/src/chef_wm_clients.erl
+++ b/src/chef_wm_clients.erl
@@ -137,41 +137,5 @@ all_clients_json(Req, #base_state{chef_db_context = DbContext,
     UriMap = [ {Name, RouteFun(Name)} || Name <- ClientNames ],
     chef_json:encode({UriMap}).
 
-% TODO: this could stand refactoring: I'm sure there is stuff re-used by other
-% endpoints and possibly unused code here
-error_message(Msg) when is_list(Msg) ->
-    error_message(iolist_to_binary(Msg));
-error_message(Msg) when is_binary(Msg) ->
-    {[{<<"error">>, [Msg]}]}.
-
-malformed_request_message(#ej_invalid{type = json_type, key = Key}, _Req, _State) ->
-    case Key of
-        undefined -> error_message([<<"Incorrect JSON type for request body">>]);
-        _ ->error_message([<<"Incorrect JSON type for ">>, Key])
-    end;
-malformed_request_message(#ej_invalid{type = missing, key = Key}, _Req, _State) ->
-    error_message([<<"Required value for ">>, Key, <<" is missing">>]);
-malformed_request_message({invalid_key, Key}, _Req, _State) ->
-    error_message([<<"Invalid key ">>, Key, <<" in request body">>]);
-malformed_request_message(invalid_json_object, _Req, _State) ->
-    error_message([<<"Incorrect JSON type for request body">>]);
-malformed_request_message(#ej_invalid{type = exact, key = Key, msg = Expected},
-                          _Req, _State) ->
-    error_message([Key, <<" must equal ">>, Expected]);
-malformed_request_message(#ej_invalid{type = string_match, msg = Error},
-                          _Req, _State) ->
-    error_message([Error]);
-malformed_request_message(#ej_invalid{type = object_key, key = Object, found = Key},
-                          _Req, _State) ->
-    error_message([<<"Invalid key '">>, Key, <<"' for ">>, Object]);
-% TODO: next two tests can get merged (hopefully) when object_map is extended not
-% to swallow keys
-malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
-                          _Req, _State) when is_binary(Val) ->
-    error_message([<<"Invalid value '">>, Val, <<"' for ">>, Object]);
-malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
-                          _Req, _State) ->
-    error_message([<<"Invalid value '">>, io_lib:format("~p", [Val]),
-                   <<"' for ">>, Object]);
 malformed_request_message(Any, Req, State) ->
     chef_wm_util:malformed_request_message(Any, Req, State).

--- a/src/chef_wm_cookbook_version.erl
+++ b/src/chef_wm_cookbook_version.erl
@@ -198,41 +198,8 @@ malformed_request_message(#ej_invalid{type = array_elt,
                                       key = Key},
                           _Req, _State) ->
     error_message([<<"Invalid element in array value of '">>, Key, <<"'.">>]);
-malformed_request_message(#ej_invalid{type = Type,
-                                      key = <<"metadata.", _/binary>>= Key,
-                                      msg = undefined},
-                          _Req, _State) when Type =:= object_value;
-                                             Type =:= object_key ->
-    error_message([<<"Unexpected value for '">>, Key, <<"'.">>]);
-malformed_request_message(#ej_invalid{type = Type,
-                                      key = <<"metadata.", _/binary>>= Key,
-                                      msg = Msg},
-                          _Req, _State) when Type =:= object_value;
-                                             Type =:= object_key ->
-    error_message([Msg, <<" for '">>, Key, <<"'.">>]);
-malformed_request_message(#ej_invalid{type = missing, key = Key }, _Req, _State) ->
-    error_message([<<"Required key '">>, Key, <<"' not found in JSON.">>]);
-malformed_request_message(#ej_invalid{type = exact, key = Key, msg = Expected,
-                                      found = Found, found_type = FType}, _Req, _State) ->
-    Msg0 = [<<"Value for '">>, Key, <<"' must be '">>, Expected],
-    Msg = case FType of
-              string ->
-                  Msg0 ++ [<<"', found: '">>, Found, <<"'.">>];
-              _ ->
-                  Msg0 ++ [<<"'.">>]
-          end,
-    error_message(Msg);
-malformed_request_message(#ej_invalid{type = json_type, key = Key,
-                                      expected_type = EType,
-                                      found_type = FType}, _Req, _State) ->
-    Msg = [<<"Value for key '">>, Key, <<"' must have type '">>,
-           atom_to_binary(EType, utf8), <<"', found '">>,
-           atom_to_binary(FType, utf8), <<"'.">>],
-    error_message(Msg);
 
-malformed_request_message(#ej_invalid{type = string_match, found = Found, key = Key, msg = Error}, _Req, _State) ->
-    Msg = [<<"Invalid value ">>, Found, <<" for key ">>, Key, " must match ", Error],
-    error_message(Msg);
+
 malformed_request_message({bad_cookbook_name, Name, Pattern}, _Req, _State) ->
     Msg = [<<"Invalid cookbook name '">>, Name, <<"' using regex: '">>, Pattern, <<"'.">>],
     error_message(Msg);

--- a/src/chef_wm_depsolver.erl
+++ b/src/chef_wm_depsolver.erl
@@ -66,14 +66,6 @@ request_type() ->
 allowed_methods(Req, State) ->
     {['POST'], Req, State}.
 
-%% TODO: More specific error messages for bad run_list element and content
-malformed_request_message(#ej_invalid{type = json_type}, _Req, _State) ->
-    {[{<<"error">>, [<<"Field 'run_list' is not a valid run list">>]}]};
-malformed_request_message(#ej_invalid{type = array_elt}, _Req, _State) ->
-    {[{<<"error">>, [<<"Field 'run_list' is not a valid run list">>]}]};
-malformed_request_message({environment_not_found, Name}, _Req, _State) ->
-    Msg = iolist_to_binary(["environment '", Name, "' not found"]),
-    {[{<<"error">>, [Msg]}]};
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
 

--- a/src/chef_wm_environments.erl
+++ b/src/chef_wm_environments.erl
@@ -112,41 +112,5 @@ all_environments_json(Req, #base_state{chef_db_context = DbContext,
     UriMap= [{Name, RouteFun(Name)} || Name <- EnvNames],
     chef_json:encode({UriMap}).
 
-% TODO: this could stand refactoring: I'm sure there is stuff re-used by other
-% endpoints and possibly unused code here
-error_message(Msg) when is_list(Msg) ->
-    error_message(iolist_to_binary(Msg));
-error_message(Msg) when is_binary(Msg) ->
-    {[{<<"error">>, [Msg]}]}.
-
-malformed_request_message(#ej_invalid{type = json_type, key = Key}, _Req, _State) ->
-    case Key of
-        undefined -> error_message([<<"Incorrect JSON type for request body">>]);
-        _ ->error_message([<<"Incorrect JSON type for ">>, Key])
-    end;
-malformed_request_message(#ej_invalid{type = missing, key = Key}, _Req, _State) ->
-    error_message([<<"Required value for ">>, Key, <<" is missing">>]);
-malformed_request_message({invalid_key, Key}, _Req, _State) ->
-    error_message([<<"Invalid key ">>, Key, <<" in request body">>]);
-malformed_request_message(invalid_json_object, _Req, _State) ->
-    error_message([<<"Incorrect JSON type for request body">>]);
-malformed_request_message(#ej_invalid{type = exact, key = Key, msg = Expected},
-                          _Req, _State) ->
-    error_message([Key, <<" must equal ">>, Expected]);
-malformed_request_message(#ej_invalid{type = string_match, msg = Error},
-                          _Req, _State) ->
-    error_message([Error]);
-malformed_request_message(#ej_invalid{type = object_key, key = Object, found = Key},
-                          _Req, _State) ->
-    error_message([<<"Invalid key '">>, Key, <<"' for ">>, Object]);
-% TODO: next two tests can get merged (hopefully) when object_map is extended not
-% to swallow keys
-malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
-                          _Req, _State) when is_binary(Val) ->
-    error_message([<<"Invalid value '">>, Val, <<"' for ">>, Object]);
-malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
-                          _Req, _State) ->
-    error_message([<<"Invalid value '">>, io_lib:format("~p", [Val]),
-                   <<"' for ">>, Object]);
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).

--- a/src/chef_wm_malformed.erl
+++ b/src/chef_wm_malformed.erl
@@ -1,0 +1,204 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% @author Christopher Maier <cm@opscode.com>
+%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(chef_wm_malformed).
+
+-include("chef_wm.hrl").
+
+-export([
+         malformed_request_message/3
+        ]).
+
+%% @doc Handle common malformed request tasks with resource-specific callbacks
+%%
+%% This function does a sanity check on the authn headers (not verifying signing, but does
+%% all checks it can without talking to a db).  It also checks for org existence and halts
+%% with 404 if the org is not found.  This doesn't strictly belong in malformed_request, but
+%% right now all of our resources need this check and end up needing it before
+%% resource_exists will get called so we do it here.
+%%
+%% The caller provides `ValidateFun' which will be given `Req' and `State' as args and
+%% should return a `{Req, State}' tuple or throw.  The `ErrorMsgFun' will be called as
+%% `ErrorMsgFun(Reason, Req, State)' where `Reason' is the term thrown by `ValidateFun'.
+%%
+malformed_request_message(bad_clock, Req, State) ->
+    {GetHeader, _State1} = chef_wm_util:get_header_fun(Req, State),
+    User = case GetHeader(<<"X-Ops-UserId">>) of
+               undefined -> <<"">>;
+               UID -> UID
+           end,
+    Msg = iolist_to_binary([<<"Failed to authenticate as ">>, User,
+                            <<". Synchronize the clock on your host.">>]),
+    {[{<<"error">>, [Msg]}]};
+malformed_request_message(bad_sign_desc, _Req, _State) ->
+    Msg = <<"Unsupported authentication protocol version">>,
+    {[{<<"error">>, [Msg]}]};
+malformed_request_message({missing_headers, Missing}, _Req, _State) ->
+    Msg = iolist_to_binary([
+                            <<"missing required authentication header(s) ">>,
+                            bin_str_join(Missing, <<", ">>)]),
+    {[{<<"error">>, [Msg]}]};
+malformed_request_message({bad_headers, Bad}, _Req, _State) ->
+    Msg = iolist_to_binary([
+                            <<"bad header(s) ">>,
+                            bin_str_join(Bad, <<", ">>)]),
+    {[{<<"error">>, [Msg]}]};
+malformed_request_message({error, invalid_json}, _Req, _State) ->
+    %% in theory, there might be some sort of slightly useful error detail from
+    %% chef_json/jiffy, but thus far nothing specific enough to beat out this. Also, would
+    %% not passing internal library error messages out to the user when possible.
+    {[{<<"error">>, [<<"invalid JSON">>]}]};
+malformed_request_message({mismatch, {FieldName, _Pat, _Val}}, _Req, _State) ->
+    {[{<<"error">>, [iolist_to_binary(["Field '", FieldName, "' invalid"])]}]};
+malformed_request_message({missing, FieldName}, _Req, _State) ->
+    {[{<<"error">>, [iolist_to_binary(["Field '", FieldName, "' missing"])]}]};
+malformed_request_message({both_missing, Field1, _Field2}, _Req, _State) ->
+    {[{<<"error">>, [iolist_to_binary(["Field '", Field1, "' missing"])]}]};
+malformed_request_message({client_name_mismatch}, _Req, _State) ->
+    {[{<<"error">>, [<<"name and clientname must match">>]}]};
+malformed_request_message({bad_client_name, Name, Pattern}, _Req, _State) ->
+    {[{<<"error">>, [iolist_to_binary(["Invalid client name '", Name,
+                                       "' using regex: '", Pattern, "'."])]}]};
+
+%% Not sure if we want to be this specific, or just want to fold this into an 'invalid JSON'
+%% case.  At any rate, here it is.
+malformed_request_message({bad_string_list, {Field, _Value}}, _Req, _State) ->
+    {[{<<"error">>, [iolist_to_binary(["Field '", Field, "' is not a list of strings"])]}]};
+malformed_request_message({bad_ejson_proplist, {Field, _Value}}, _Req, _State) ->
+    {[{<<"error">>, [iolist_to_binary(["Field '", Field, "' is not a hash"])]}]};
+malformed_request_message({url_json_name_mismatch, {_UrlName, _Mismatch, Type}}, _Req, _State) ->
+    {[{<<"error">>, [iolist_to_binary([Type, <<" name mismatch.">>])]}]};
+malformed_request_message({bad_run_list, {Field, _Value}}, _Req, _State) ->
+    {[{<<"error">>, [iolist_to_binary(["Field '", Field, "' is not a valid run list"])]}]};
+malformed_request_message({bad_run_lists, {Field, _Value}}, _Req, _State) ->
+    {[{<<"error">>, [iolist_to_binary(["Field '", Field, "' contains invalid run lists"])]}]};
+malformed_request_message(invalid_num_versions, _Req, _State) ->
+    {[{<<"error">>, [<<"You have requested an invalid number of versions (x >= 0 || 'all')">>]}]};
+
+%% This is used by some custom validation in environments that may (or may not!) be pulled up into ej:valid validations
+malformed_request_message({invalid_key, Key}, _Req, _State) ->
+    error_envelope([<<"Invalid key ">>, Key, <<" in request body">>]);
+
+malformed_request_message(invalid_json_object, _Req, _State) ->
+    error_envelope([<<"Incorrect JSON type for request body">>]);
+
+%% General ej_invalid messages
+
+%% Missing fields
+malformed_request_message(#ej_invalid{type=missing,
+                                      key=Key
+                                     }, _Req, _State) ->
+    error_envelope([<<"Field '", Key/binary, "' missing">>]);
+
+%% Exact and string_match failures
+malformed_request_message(#ej_invalid{type=Type,
+                                      key=Key
+                                     }, _Req, _State) when Type =:= exact ;
+                                                           Type =:= string_match ->
+    error_envelope([<<"Field '", Key/binary, "' invalid">>]);
+
+%% Things that should be hashes, but aren't.
+malformed_request_message(#ej_invalid{type=json_type,
+                                      key=Key
+                                     }, _Req, _State) when Key =:= <<"override_attributes">> ;
+                                                           Key =:= <<"default_attributes">> ;
+                                                           Key =:= <<"normal">> ;
+                                                           Key =:= <<"default">> ;
+                                                           Key =:= <<"override">> ;
+                                                           Key =:= <<"automatic">> ;
+                                                           Key =:= <<"cookbook_versions">> ->
+    error_envelope([<<"Field '", Key/binary, "' is not a hash">>]);
+
+%% Entire run list is the wrong type
+malformed_request_message(#ej_invalid{type=json_type,
+                                     key=Key}, _Req, _State) when Key =:= <<"run_list">> ->
+    error_envelope([<<"Field '", Key/binary,"' is not a valid run list">>]);
+
+%% entire env_run_lists is the wrong type
+malformed_request_message(#ej_invalid{type=json_type,
+                                      key=Key
+                                     }, _Req, _State) when Key =:= <<"env_run_lists">> ->
+    error_envelope([<<"Field '", Key/binary, "' contains invalid run lists">>]);
+
+%% All other json_type failures
+malformed_request_message(#ej_invalid{type=json_type,
+                                      key=Key
+                                     }, _Req, _State) ->
+    error_envelope([<<"Field '", Key/binary, "' invalid">>]);
+
+%% Bogus run list items
+%%
+%% In the future, we may wish to add more detailed error messages reflecting whether a run
+%% list item is simply the wrong type (e.g., a number) or an invalid run list item (e.g.,
+%% the string "recipe[").  To do so, we would need to compare the `found_type` and
+%% `expected_type` record fields
+malformed_request_message(#ej_invalid{type=array_elt,
+                                      key=Key}, _Req, _State) when Key =:= <<"run_list">> ->
+    error_envelope([<<"Field '", Key/binary, "' is not a valid run list">>]);
+
+malformed_request_message(#ej_invalid{type = object_key,
+                                      key = Object,
+                                      found = Key}, _Req, _State) ->
+    error_envelope([<<"Invalid key '">>, Key, <<"' for ">>, Object]);
+
+malformed_request_message(#ej_invalid{type = object_value,
+                                      key = Key
+                                     }, _Req, _State) when Key =:= <<"env_run_lists">> ->
+    error_envelope([<<"Field '", Key/binary, "' contains invalid run lists">>]);
+
+malformed_request_message(#ej_invalid{type = object_value,
+                                      key = Object,
+                                      found = Val}, _Req, _State) ->
+    error_envelope([<<"Invalid value '">>, Val, <<"' for ">>, Object]);
+
+
+malformed_request_message(Reason, Req, #base_state{resource_mod=Mod}=State) ->
+    Mod:malformed_request_message(Reason, Req, State).
+
+
+bin_str_join(L, Sep) ->
+    bin_str_join(L, Sep, []).
+
+bin_str_join([H], _Sep, Acc) ->
+    lists:reverse([<<"'">>, H, <<"'">>|Acc]);
+bin_str_join([H | T], Sep, Acc) ->
+    bin_str_join(T, Sep, [Sep, <<"'">>, H, <<"'">> | Acc]).
+
+
+-spec to_binary( any() ) -> binary().
+to_binary(A) when is_atom(A) ->
+    atom_to_binary(A, utf8);
+to_binary(I) when is_integer(I)->
+    list_to_binary(integer_to_list(I));
+to_binary(B) when is_binary(B)->
+    B;
+to_binary(O) ->
+    %% Catch-all case
+    list_to_binary(io_lib:format("~p", [O])).
+
+-spec binary_message([atom() | string() | binary()]) -> binary().
+binary_message(Parts)  ->
+    iolist_to_binary([to_binary(P) || P <- Parts]).
+
+-spec error_envelope(binary() | [binary()]) -> ej:json_object().
+error_envelope(Parts) when is_list(Parts) ->
+    error_envelope(binary_message(Parts));
+error_envelope(Message) when is_binary(Message) ->
+    chef_wm_util:error_message_envelope(Message).

--- a/src/chef_wm_named_client.erl
+++ b/src/chef_wm_named_client.erl
@@ -152,42 +152,5 @@ maybe_generate_key_pair(ClientData, RequestId) ->
             ClientData
     end.
 
-% TODO: this could stand refactoring: I'm sure there is stuff re-used by other
-% endpoints and possibly unused code here
-error_message(Msg) when is_list(Msg) ->
-    error_message(iolist_to_binary(Msg));
-error_message(Msg) when is_binary(Msg) ->
-    {[{<<"error">>, [Msg]}]}.
-
-malformed_request_message(#ej_invalid{type = json_type, key = Key}, _Req, _State) ->
-    case Key of
-        undefined -> error_message([<<"Incorrect JSON type for request body">>]);
-        _ ->error_message([<<"Incorrect JSON type for ">>, Key])
-    end;
-malformed_request_message(#ej_invalid{type = missing, key = Key}, _Req, _State) ->
-    error_message([<<"Required value for ">>, Key, <<" is missing">>]);
-malformed_request_message({invalid_key, Key}, _Req, _State) ->
-    error_message([<<"Invalid key ">>, Key, <<" in request body">>]);
-malformed_request_message(invalid_json_object, _Req, _State) ->
-    error_message([<<"Incorrect JSON type for request body">>]);
-malformed_request_message(#ej_invalid{type = exact, key = Key, msg = Expected},
-                          _Req, _State) ->
-    error_message([Key, <<" must equal ">>, Expected]);
-malformed_request_message(#ej_invalid{type = string_match, msg = Error},
-                          _Req, _State) ->
-    error_message([Error]);
-malformed_request_message(#ej_invalid{type = object_key, key = Object, found = Key},
-                          _Req, _State) ->
-    error_message([<<"Invalid key '">>, Key, <<"' for ">>, Object]);
-% TODO: next two tests can get merged (hopefully) when object_map is extended not
-% to swallow keys
-malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
-                          _Req, _State) when is_binary(Val) ->
-    error_message([<<"Invalid value '">>, Val, <<"' for ">>, Object]);
-malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
-                          _Req, _State) ->
-    error_message([<<"Invalid value '">>, io_lib:format("~p", [Val]),
-                   <<"' for ">>, Object]);
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
-

--- a/src/chef_wm_named_environment.erl
+++ b/src/chef_wm_named_environment.erl
@@ -119,40 +119,5 @@ delete_resource(Req, #base_state{chef_db_context = DbContext,
     Json = chef_db_compression:decompress(Environment#chef_environment.serialized_object),
     {true, wrq:set_resp_body(Json, Req), State}.
 
-% TODO: this needs to be refactored; repeated from chef_wm_environments
-error_message(Msg) when is_list(Msg) ->
-    error_message(iolist_to_binary(Msg));
-error_message(Msg) when is_binary(Msg) ->
-    {[{<<"error">>, [Msg]}]}.
-
-malformed_request_message(#ej_invalid{type = json_type, key = Key}, _Req, _State) ->
-    case Key of
-        undefined -> error_message([<<"Incorrect JSON type for request body">>]);
-        _ ->error_message([<<"Incorrect JSON type for ">>, Key])
-    end;
-malformed_request_message(#ej_invalid{type = missing, key = Key}, _Req, _State) ->
-    error_message([<<"Required value for ">>, Key, <<" is missing">>]);
-malformed_request_message({invalid_key, Key}, _Req, _State) ->
-    error_message([<<"Invalid key ">>, Key, <<" in request body">>]);
-malformed_request_message(invalid_json_object, _Req, _State) ->
-    error_message([<<"Incorrect JSON type for request body">>]);
-malformed_request_message(#ej_invalid{type = exact, key = Key, msg = Expected},
-                          _Req, _State) ->
-    error_message([Key, <<" must equal ">>, Expected]);
-malformed_request_message(#ej_invalid{type = string_match, msg = Error},
-                          _Req, _State) ->
-    error_message([Error]);
-malformed_request_message(#ej_invalid{type = object_key, key = Object, found = Key},
-                          _Req, _State) ->
-    error_message([<<"Invalid key '">>, Key, <<"' for ">>, Object]);
-% TODO: next two tests can get merged (hopefully) when object_map is extended not
-% to swallow keys
-malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
-                          _Req, _State) when is_binary(Val) ->
-    error_message([<<"Invalid value '">>, Val, <<"' for ">>, Object]);
-malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
-                          _Req, _State) ->
-    error_message([<<"Invalid value '">>, io_lib:format("~p", [Val]),
-                   <<"' for ">>, Object]);
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).

--- a/src/chef_wm_sandboxes.erl
+++ b/src/chef_wm_sandboxes.erl
@@ -94,17 +94,17 @@ from_json(Req, #base_state{chef_db_context = DbContext,
             {{halt, 500}, Req, State}
     end.
 
-malformed_request_message({empty_checksums, Msg}, _Req, _State) ->
-    chef_wm_util:error_message_envelope(Msg);
-malformed_request_message({bad_checksum, Msg}, _Req, _State) ->
-    chef_wm_util:error_message_envelope(Msg);
+malformed_request_message(#ej_invalid{type=fun_match,
+                                      key=Key,
+                                      msg=Message
+                                     }, _Req, _State) when Key =:= <<"checksums">> ->
+    {[{<<"error">>, [<<"Field '", Key/binary, "' invalid">>]}]};
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
 
 checksums_from_sandbox_ejson(SandboxData) ->
     {ChecksumList} = ej:get({<<"checksums">>}, SandboxData),
     [ CSum || {CSum, null} <- ChecksumList ].
-
 
 sandbox_to_response(Req, #chef_sandbox{id = Id, org_id = OrgId, checksums = ChecksumList}) ->
     Ans = {[{<<"sandbox_id">>, Id},

--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -28,7 +28,6 @@
          extract_from_path/2,
          full_uri/1,
          get_header_fun/2,
-         malformed_request_message/3,
          base_mods/0,
          not_found_message/2,
          num_versions/1,
@@ -198,44 +197,6 @@ extract_from_path(PathKey, Req) ->
         Value ->
             list_to_binary(Value)
     end.
-
-error_message(Msg) when is_list(Msg) ->
-    error_message(iolist_to_binary(Msg));
-error_message(Msg) when is_binary(Msg) ->
-    {[{<<"error">>, [Msg]}]}.
-
-malformed_request_message(#ej_invalid{type = json_type, key = Key}, _Req, _State) ->
-    case Key of
-        undefined -> error_message([<<"Incorrect JSON type for request body">>]);
-        _ ->error_message([<<"Incorrect JSON type for ">>, Key])
-    end;
-malformed_request_message(#ej_invalid{type = missing, key = Key}, _Req, _State) ->
-    error_message([<<"Required value for ">>, Key, <<" is missing">>]);
-malformed_request_message({invalid_key, Key}, _Req, _State) ->
-    error_message([<<"Invalid key ">>, Key, <<" in request body">>]);
-malformed_request_message(invalid_json_object, _Req, _State) ->
-    error_message([<<"Incorrect JSON type for request body">>]);
-malformed_request_message(#ej_invalid{type = exact, key = Key, msg = Expected},
-                          _Req, _State) ->
-    error_message([Key, <<" must equal ">>, Expected]);
-malformed_request_message(#ej_invalid{type = string_match, msg = Error},
-                          _Req, _State) ->
-    error_message([Error]);
-malformed_request_message(#ej_invalid{type = object_key, key = Object, found = Key},
-                          _Req, _State) ->
-    error_message([<<"Invalid key '">>, Key, <<"' for ">>, Object]);
-% TODO: next two tests can get merged (hopefully) when object_map is extended not
-% to swallow keys
-malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
-                          _Req, _State) when is_binary(Val) ->
-    error_message([<<"Invalid value '">>, Val, <<"' for ">>, Object]);
-malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
-                          _Req, _State) ->
-    error_message([<<"Invalid value '">>, io_lib:format("~p", [Val]),
-                   <<"' for ">>, Object]);
-malformed_request_message(Any, _Req, _State) ->
-    error({unexpected_malformed_request_message, Any}).
-
 
 %% @doc Utility function to process the `num_versions' parameter that is common to several
 %% cookbook-related resources


### PR DESCRIPTION
Adds necessary `#ej_invalid{}` matching clauses to `malformed_message_request/3`.  Standardizes many error messages, deleting much of the duplicated and duplicated-except-for-some-tiny-differences code that was scattered across multiple endpoints.

These PRs are required for full effect:
- https://github.com/opscode/chef_objects/pull/17
- https://github.com/opscode/chef-pedant-core/pull/10
- https://github.com/opscode/chef-pedant-tests/pull/8
