### PR TITLE
callback spec for auth_info was broken

### DIFF
--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -41,6 +41,19 @@
 -define(BASE_ROUTES, chef_wm_routes).
 -endif.
 
+-type permission() :: create | delete | read | update.
+
+-type container_name() :: cookbook |
+                          data |
+                          environment |
+                          node |
+                          role |
+                          client |
+                          sandbox.
+
+-type auth_tuple() :: {object, object_id(), permission()} |
+                      {container, container_name(), permission()}.
+
 -type wm_req() :: #wm_reqdata{}.
 
 %% Shared resource state shared by all chef_wm resource modules.

--- a/src/chef_wm.erl
+++ b/src/chef_wm.erl
@@ -23,13 +23,7 @@
 -type http_verb() :: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'HEAD' | 'OPTIONS'.
 -type base_state() :: #base_state{}.
 -type resource_state() :: term().
--type container_name() :: cookbook |
-                          data |
-                          environment |
-                          node |
-                          role |
-                          client |
-                          sandbox.
+
 -callback init(list()) ->
     {ok, base_state()} | error().
 
@@ -50,4 +44,5 @@
     {{create_in_container, container_name()}, wm_req(), base_state()} |
     {{container, container_name()}, wm_req(), base_state()} |
     {{object, object_id()}, wm_req(), base_state()} |
+    {[auth_tuple()], wm_req(), base_state()} |
     {authorized, wm_req(), base_state()}.


### PR DESCRIPTION
- Move some types into chef_wm.hrl so they can be shared
- Fixed auth_info/2 callback spec
