### PR TITLE
Jc/rename authz flags

### DIFF
--- a/src/chef_wm_authz.erl
+++ b/src/chef_wm_authz.erl
@@ -29,7 +29,7 @@
          allow_validator/1,
          is_admin/1,
          is_validator/1,
-         use_custom_acls/2]).
+         use_custom_acls/4]).
 
 -include("chef_wm.hrl").
 
@@ -70,17 +70,21 @@ is_validator(#chef_client{}) ->
 
 -spec use_custom_acls(Endpoint :: atom(),
                       Auth :: {object, object_id()} |
-                              {container, container_name()} | [auth_tuple()])
+                              {container, container_name()} | [auth_tuple()],
+                      Req :: wm:req(),
+                      State :: #base_state{})
     -> authorized | {object, object_id()} | {container, container_name()} | [auth_tuple()].
 %% Check if we should use custom acls for an endpoint. If the config variable is false,
 %% the we don't check the object/container ACLs and instead use the fact that a client has
 %% passed authn is enough
-use_custom_acls(Endpoint, Auth) ->
+use_custom_acls(_Endpoint, Auth, Req, #base_state{requestor = #chef_user{} } = State) ->
+    {Auth, Req, State};
+use_custom_acls(Endpoint, Auth, Req, #base_state{requestor = #chef_client{} } = State) ->
     case application:get_env(oc_chef_wm, config_for(Endpoint)) of
         {ok, false} ->
-            authorized;
+            {authorized, Req, State};
         _Else -> %% use standard behaviour
-            Auth
+            {Auth, Req, State}
     end.
 
 config_for(cookbooks) ->

--- a/src/chef_wm_authz.erl
+++ b/src/chef_wm_authz.erl
@@ -82,9 +82,25 @@ use_custom_acls(_Endpoint, Auth, Req, #base_state{requestor = #chef_user{} } = S
 use_custom_acls(Endpoint, Auth, Req, #base_state{requestor = #chef_client{} } = State) ->
     case application:get_env(oc_chef_wm, config_for(Endpoint)) of
         {ok, false} ->
-            {authorized, Req, State};
+            handle_always_for_modification(Auth, Req, State);
         _Else -> %% use standard behaviour
             {Auth, Req, State}
+    end.
+
+%% Allow the option to use_custom_acls always for create,update,delete methods
+%% all requests. If set to true the 'custom_acls_FOO' flags only apply to the GET
+%% method.
+%%
+%% Controlled by the config variable {oc_chef_wm, custom_acls_not_on_get}
+handle_always_for_modification(Auth, Req, State) ->
+    {ok, AlwaysForModification} = application:get_env(oc_chef_wm, custom_acls_always_for_modification),
+    case {wm:method(Req), AlwaysForModification} of
+        {'GET', true} ->
+            {authorized, Req, State};
+        {_Method, true} ->
+            {Auth, Req, State};
+        {_Method, false} ->
+            {authorized, Req, State}
     end.
 
 config_for(cookbooks) ->

--- a/src/chef_wm_authz.erl
+++ b/src/chef_wm_authz.erl
@@ -29,7 +29,7 @@
          allow_validator/1,
          is_admin/1,
          is_validator/1,
-         maybe_check_authz/2]).
+         use_custom_acls/2]).
 
 -include("chef_wm.hrl").
 
@@ -68,17 +68,27 @@ is_validator(#chef_client{validator = true}) ->
 is_validator(#chef_client{}) ->
     false.
 
--spec maybe_check_authz(atom(),
-                        {object, object_id()} |
-                        {container, container_name()} | [auth_tuple()])
+-spec use_custom_acls(Endpoint :: atom(),
+                      Auth :: {object, object_id()} |
+                              {container, container_name()} | [auth_tuple()])
     -> authorized | {object, object_id()} | {container, container_name()} | [auth_tuple()].
-
-maybe_check_authz(ConfigName, Auth) ->
-    case application:get_env(oc_chef_wm, ConfigName) of
-        {ok, true} ->
+%% Check if we should use custom acls for an endpoint. If the config variable is false,
+%% the we don't check the object/container ACLs and instead use the fact that a client has
+%% passed authn is enough
+use_custom_acls(Endpoint, Auth) ->
+    case application:get_env(oc_chef_wm, config_for(Endpoint)) of
+        {ok, false} ->
             authorized;
         _Else -> %% use standard behaviour
             Auth
     end.
 
+config_for(cookbooks) ->
+    custom_acls_cookbooks;
+config_for(roles) ->
+    custom_acls_roles;
+config_for(data) ->
+    custom_acls_data;
+config_for(depsolver) ->
+    custom_acls_depsolver.
 

--- a/src/chef_wm_authz.erl
+++ b/src/chef_wm_authz.erl
@@ -74,33 +74,34 @@ is_validator(#chef_client{}) ->
                       Req :: wm:req(),
                       State :: #base_state{})
     -> authorized | {object, object_id()} | {container, container_name()} | [auth_tuple()].
-%% Check if we should use custom acls for an endpoint. If the config variable is false,
-%% the we don't check the object/container ACLs and instead use the fact that a client has
-%% passed authn is enough
+%% Check if we should use contact opscode-authz and chef requestor-specific acls for an endpoint.
+%% If the config variable is false, then we don't check the object/container ACLs and instead
+%% use the fact that a client has passed authn as allowing them to access a resource
 use_custom_acls(_Endpoint, Auth, Req, #base_state{requestor = #chef_user{} } = State) ->
     {Auth, Req, State};
 use_custom_acls(Endpoint, Auth, Req, #base_state{requestor = #chef_client{} } = State) ->
     case application:get_env(oc_chef_wm, config_for(Endpoint)) of
         {ok, false} ->
-            handle_always_for_modification(Auth, Req, State);
+            customize_for_modification_maybe(wm:method(Req), Auth, Req, State);
         _Else -> %% use standard behaviour
             {Auth, Req, State}
     end.
 
-%% Allow the option to use_custom_acls always for create,update,delete methods
-%% all requests. If set to true the 'custom_acls_FOO' flags only apply to the GET
-%% method.
+%% Allow the option to contact opscode-authz with custom acls for all create,update,delete
+%% requests. When 'custom_acls_always_for_modification' is set to true the
+%% 'custom_acls_FOO' flags only apply to the GET method.
 %%
-%% Controlled by the config variable {oc_chef_wm, custom_acls_not_on_get}
-handle_always_for_modification(Auth, Req, State) ->
-    {ok, AlwaysForModification} = application:get_env(oc_chef_wm, custom_acls_always_for_modification),
-    case {wm:method(Req), AlwaysForModification} of
-        {'GET', true} ->
-            {authorized, Req, State};
-        {_Method, true} ->
+%% Controlled by the config variable {oc_chef_wm, custom_acls_always_for_modification}
+customize_for_modification_maybe('GET', Auth, Req, State) ->
+    {authorized, Req, State};
+customize_for_modification_maybe(_Method, Auth, Req, State) ->
+    case application:get_env(oc_chef_wm, custom_acls_always_for_modification) of
+        {ok, true} ->
             {Auth, Req, State};
-        {_Method, false} ->
-            {authorized, Req, State}
+        {ok, false} ->
+            {authorized, Req, State};
+        _Else ->
+            {Auth, Req, State}
     end.
 
 config_for(cookbooks) ->

--- a/src/chef_wm_cookbook_version.erl
+++ b/src/chef_wm_cookbook_version.erl
@@ -93,7 +93,7 @@ auth_info(Req, #base_state{chef_db_context = DbContext,
             CookbookState1 = CookbookState#cookbook_state{authz_id = AuthzId,
                                                           chef_cookbook_version = CookbookVersion},
             State1 = State#base_state{resource_state = CookbookState1},
-            {chef_wm_authz:maybe_check_authz(authz_skip_cookbooks, {object, AuthzId}),
+            {chef_wm_authz:use_custom_acls(cookbooks, {object, AuthzId}),
              Req, State1}
     end.
 
@@ -190,7 +190,7 @@ handle_not_found(Req, #base_state{} = State) ->
 handle_cookbook_exists(Req, #base_state{resource_state = #cookbook_state{authz_id = AuthzId}} = State) ->
     case wrq:method(Req) of
         'PUT' ->
-            {chef_wm_authz:maybe_check_authz(authz_skip_cookbooks, {object, AuthzId}),
+            {chef_wm_authz:use_custom_acls(cookbooks, {object, AuthzId}),
              Req, State};
         _ ->
             construct_not_found_response(Req, State)

--- a/src/chef_wm_cookbook_version.erl
+++ b/src/chef_wm_cookbook_version.erl
@@ -93,8 +93,7 @@ auth_info(Req, #base_state{chef_db_context = DbContext,
             CookbookState1 = CookbookState#cookbook_state{authz_id = AuthzId,
                                                           chef_cookbook_version = CookbookVersion},
             State1 = State#base_state{resource_state = CookbookState1},
-            {chef_wm_authz:use_custom_acls(cookbooks, {object, AuthzId}),
-             Req, State1}
+            chef_wm_authz:use_custom_acls(cookbooks, {object, AuthzId}, Req, State1)
     end.
 
 is_conflict(Req, #base_state{}=State) ->
@@ -190,8 +189,7 @@ handle_not_found(Req, #base_state{} = State) ->
 handle_cookbook_exists(Req, #base_state{resource_state = #cookbook_state{authz_id = AuthzId}} = State) ->
     case wrq:method(Req) of
         'PUT' ->
-            {chef_wm_authz:use_custom_acls(cookbooks, {object, AuthzId}),
-             Req, State};
+            chef_wm_authz:use_custom_acls(cookbooks, {object, AuthzId}, Req, State);
         _ ->
             construct_not_found_response(Req, State)
     end.

--- a/src/chef_wm_cookbooks.erl
+++ b/src/chef_wm_cookbooks.erl
@@ -68,7 +68,7 @@ validate_request('GET', Req, #base_state{resource_state = CBState0} = State) ->
     {Req, State1}.
 
 auth_info(Req, State) ->
-    {chef_wm_authz:use_custom_acls(cookbooks, {container, cookbook}), Req, State}.
+    chef_wm_authz:use_custom_acls(cookbooks, {container, cookbook}, Req, State).
 
 %% @doc We generate three different kinds of JSON responses from this resource, based on the
 %% `qualifier' URL path element.  If this is not present, then the 'default' JSON response

--- a/src/chef_wm_cookbooks.erl
+++ b/src/chef_wm_cookbooks.erl
@@ -68,7 +68,7 @@ validate_request('GET', Req, #base_state{resource_state = CBState0} = State) ->
     {Req, State1}.
 
 auth_info(Req, State) ->
-    {chef_wm_authz:maybe_check_authz(authz_skip_cookbooks, {container, cookbook}), Req, State}.
+    {chef_wm_authz:use_custom_acls(cookbooks, {container, cookbook}), Req, State}.
 
 %% @doc We generate three different kinds of JSON responses from this resource, based on the
 %% `qualifier' URL path element.  If this is not present, then the 'default' JSON response

--- a/src/chef_wm_data.erl
+++ b/src/chef_wm_data.erl
@@ -81,7 +81,7 @@ auth_info(Req, State) ->
 auth_info('POST', Req, State) ->
     {{create_in_container, data}, Req, State};
 auth_info('GET', Req, State) ->
-    {chef_wm_authz:use_custom_acls(data, {container, data}), Req, State}.
+    chef_wm_authz:use_custom_acls(data, {container, data}, Req, State).
 
 resource_exists(Req, State) ->
     {true, Req, State}.

--- a/src/chef_wm_data.erl
+++ b/src/chef_wm_data.erl
@@ -81,7 +81,7 @@ auth_info(Req, State) ->
 auth_info('POST', Req, State) ->
     {{create_in_container, data}, Req, State};
 auth_info('GET', Req, State) ->
-    {chef_wm_authz:maybe_check_authz(authz_skip_data, {container, data}), Req, State}.
+    {chef_wm_authz:use_custom_acls(data, {container, data}), Req, State}.
 
 resource_exists(Req, State) ->
     {true, Req, State}.

--- a/src/chef_wm_depsolver.erl
+++ b/src/chef_wm_depsolver.erl
@@ -105,8 +105,8 @@ forbidden_for_environment(#chef_environment{authz_id = EnvAuthzId} = Env, Req,
                          #base_state{resource_state = ResourceState} = State) ->
     %% Set this here before passing it out; downstream functions will need it
     State1 = State#base_state{resource_state = ResourceState#depsolver_state{chef_environment = Env}},
-    {chef_wm_authz:maybe_check_authz(authz_skip_depsolver,[{container, cookbook, read},
-                                                           {object, EnvAuthzId, read}]),
+    {chef_wm_authz:use_custom_acls(depsolver, [{container, cookbook, read},
+                                               {object, EnvAuthzId, read}]),
      Req, State1}.
 
 post_is_create(Req, State) ->

--- a/src/chef_wm_depsolver.erl
+++ b/src/chef_wm_depsolver.erl
@@ -105,9 +105,11 @@ forbidden_for_environment(#chef_environment{authz_id = EnvAuthzId} = Env, Req,
                          #base_state{resource_state = ResourceState} = State) ->
     %% Set this here before passing it out; downstream functions will need it
     State1 = State#base_state{resource_state = ResourceState#depsolver_state{chef_environment = Env}},
-    {chef_wm_authz:use_custom_acls(depsolver, [{container, cookbook, read},
-                                               {object, EnvAuthzId, read}]),
-     Req, State1}.
+    chef_wm_authz:use_custom_acls(depsolver,
+                                  [{container, cookbook, read},
+                                   {object, EnvAuthzId, read}],
+                                  Req,
+                                  State1).
 
 post_is_create(Req, State) ->
     {false, Req, State}.

--- a/src/chef_wm_named_data.erl
+++ b/src/chef_wm_named_data.erl
@@ -120,7 +120,7 @@ auth_info(Req, #base_state{chef_db_context = DbContext,
             DataBagState1 = DataBagState#data_state{chef_data_bag = DataBag,
                                                     data_bag_name = DataBagName},
             State1 = State#base_state{resource_state = DataBagState1},
-            {chef_wm_authz:use_custom_acls(data, {object, AuthzId}), Req, State1}
+            chef_wm_authz:use_custom_acls(data, {object, AuthzId}, Req, State1)
     end.
 
 %% Org is checked for in malformed_request/2, data_bag is checked for in auth_info/2;

--- a/src/chef_wm_named_data.erl
+++ b/src/chef_wm_named_data.erl
@@ -120,7 +120,7 @@ auth_info(Req, #base_state{chef_db_context = DbContext,
             DataBagState1 = DataBagState#data_state{chef_data_bag = DataBag,
                                                     data_bag_name = DataBagName},
             State1 = State#base_state{resource_state = DataBagState1},
-            {chef_wm_authz:maybe_check_authz(authz_skip_data, {object, AuthzId}), Req, State1}
+            {chef_wm_authz:use_custom_acls(data, {object, AuthzId}), Req, State1}
     end.
 
 %% Org is checked for in malformed_request/2, data_bag is checked for in auth_info/2;

--- a/src/chef_wm_named_data_item.erl
+++ b/src/chef_wm_named_data_item.erl
@@ -96,7 +96,7 @@ auth_info(Req, #base_state{chef_db_context = DbContext,
                                                     data_bag_name = DataBagName,
                                                     data_bag_item_name = ItemName},
             State1 = State#base_state{resource_state = DataBagState1},
-            {chef_wm_authz:maybe_check_authz(authz_skip_data, {object, AuthzId}), Req, State1}
+            {chef_wm_authz:use_custom_acls(data, {object, AuthzId}), Req, State1}
     end.
 
 %% If we get here, we know that the data_bag exists and we have authz, here we'll check that

--- a/src/chef_wm_named_data_item.erl
+++ b/src/chef_wm_named_data_item.erl
@@ -96,7 +96,7 @@ auth_info(Req, #base_state{chef_db_context = DbContext,
                                                     data_bag_name = DataBagName,
                                                     data_bag_item_name = ItemName},
             State1 = State#base_state{resource_state = DataBagState1},
-            {chef_wm_authz:use_custom_acls(data, {object, AuthzId}), Req, State1}
+            chef_wm_authz:use_custom_acls(data, {object, AuthzId}, Req, State1)
     end.
 
 %% If we get here, we know that the data_bag exists and we have authz, here we'll check that

--- a/src/chef_wm_named_role.erl
+++ b/src/chef_wm_named_role.erl
@@ -96,7 +96,7 @@ auth_info(Req, #base_state{chef_db_context = DbContext,
         #chef_role{authz_id = AuthzId} = Role ->
             RoleState1 = RoleState#role_state{chef_role = Role},
             State1 = State#base_state{resource_state = RoleState1},
-            {chef_wm_authz:maybe_check_authz(authz_skip_roles, {object, AuthzId}), Req, State1}
+            {chef_wm_authz:use_custom_acls(roles, {object, AuthzId}), Req, State1}
     end.
 
 %% Org is checked for in malformed_request/2, role is checked for in forbidden/2;

--- a/src/chef_wm_named_role.erl
+++ b/src/chef_wm_named_role.erl
@@ -96,7 +96,7 @@ auth_info(Req, #base_state{chef_db_context = DbContext,
         #chef_role{authz_id = AuthzId} = Role ->
             RoleState1 = RoleState#role_state{chef_role = Role},
             State1 = State#base_state{resource_state = RoleState1},
-            {chef_wm_authz:use_custom_acls(roles, {object, AuthzId}), Req, State1}
+            chef_wm_authz:use_custom_acls(roles, {object, AuthzId}, Req, State1)
     end.
 
 %% Org is checked for in malformed_request/2, role is checked for in forbidden/2;

--- a/src/chef_wm_named_sandbox.erl
+++ b/src/chef_wm_named_sandbox.erl
@@ -64,7 +64,7 @@ allowed_methods(Req, State) ->
 auth_info(Req, State) ->
     % POST /sandboxes and PUT /sandboxes/<id> are two halves of a single upload
     % operation, so we use the same permission for both (create sandbox perm)
-    {chef_wm_authz:use_custom_acls(cookbooks, [{container, sandbox, create}]), Req, State}.
+    chef_wm_authz:use_custom_acls(cookbooks, [{container, sandbox, create}], Req, State).
 
 %% Org is checked for in malformed_request/2, sandbox is checked for in forbidden/2;
 %% if we get this far, it exists.

--- a/src/chef_wm_named_sandbox.erl
+++ b/src/chef_wm_named_sandbox.erl
@@ -64,7 +64,7 @@ allowed_methods(Req, State) ->
 auth_info(Req, State) ->
     % POST /sandboxes and PUT /sandboxes/<id> are two halves of a single upload
     % operation, so we use the same permission for both (create sandbox perm)
-    {chef_wm_authz:maybe_check_authz(authz_skip_cookbooks, [{container, sandbox, create}]), Req, State}.
+    {chef_wm_authz:use_custom_acls(cookbooks, [{container, sandbox, create}]), Req, State}.
 
 %% Org is checked for in malformed_request/2, sandbox is checked for in forbidden/2;
 %% if we get this far, it exists.

--- a/src/chef_wm_roles.erl
+++ b/src/chef_wm_roles.erl
@@ -79,7 +79,7 @@ auth_info(Req, State) ->
 auth_info('POST', Req, State) ->
     {{create_in_container, role}, Req, State};
 auth_info('GET', Req, State) ->
-    {chef_wm_authz:maybe_check_authz(authz_skip_roles, {container, role}), Req, State}.
+    {chef_wm_authz:use_custom_acls(roles, {container, role}), Req, State}.
 
 resource_exists(Req, State) ->
     {true, Req, State}.

--- a/src/chef_wm_roles.erl
+++ b/src/chef_wm_roles.erl
@@ -79,7 +79,7 @@ auth_info(Req, State) ->
 auth_info('POST', Req, State) ->
     {{create_in_container, role}, Req, State};
 auth_info('GET', Req, State) ->
-    {chef_wm_authz:use_custom_acls(roles, {container, role}), Req, State}.
+    chef_wm_authz:use_custom_acls(roles, {container, role}, Req, State).
 
 resource_exists(Req, State) ->
     {true, Req, State}.


### PR DESCRIPTION
- Renamed to custom_acls_*
- Added 'custom_acls_always_for_modification' configuration flag.
  Defaults to true, and when true means that we always use custom ACLs
  for non-GET methods regardless of the setting of custom_acls_FOO
  settings. This trades some performance for better security.
