### PR TITLE
Review of user deletion guards in sf/OC-2298

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,3 @@ dialyzer: $(DEPS_PLT)
 $(DEPS_PLT):
 	@dialyzer --build_plt $(DIALYZER_DEPS) --output_plt $(DEPS_PLT)
 
-.PHONY: check_calls

--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -203,5 +203,11 @@
           run_list_cookbooks :: [binary() | {binary(), binary()}]
         }).
 
+-record(user_state, {
+          user_data,
+          user_authz_id,
+          chef_user :: #chef_user{}
+      }).
+
 -define(gv(X,L), proplists:get_value(X, L)).
 -define(gv(X,L, D), proplists:get_value(X, L, D)).

--- a/priv/dispatch.conf
+++ b/priv/dispatch.conf
@@ -58,5 +58,6 @@
 {["search", object_type], chef_wm_search, []}.
 
 {["users"], chef_wm_users, []}.
+{["users", user_name], chef_wm_named_user, []}.
 
 {["_status"], chef_wm_status, []}.

--- a/priv/dispatch.conf
+++ b/priv/dispatch.conf
@@ -57,4 +57,6 @@
 {["search"], chef_wm_search_index, []}.
 {["search", object_type], chef_wm_search, []}.
 
+{["users"], chef_wm_users, []}.
+
 {["_status"], chef_wm_status, []}.

--- a/src/chef_object_db.erl
+++ b/src/chef_object_db.erl
@@ -98,7 +98,7 @@ delete(DbContext, Object, _RequestorId) ->
     ok.
 
 -spec delete_from_db(chef_db:db_context(),
-                     chef_object() | #chef_cookbook_version{}) -> ok.
+                     chef_object() | #chef_user{} | #chef_cookbook_version{}) -> ok.
 %% @doc Delete an object from the database.  Provides pattern-matching sugar over chef_db
 %% delete functions, making the `delete` function in this module very simple. Throws if the
 %% database call returns an error, otherwise returns `ok' ignoring specific return value
@@ -107,6 +107,8 @@ delete_from_db(DbContext, #chef_client{}=Client) ->
     handle_delete_from_db(chef_db:delete_client(DbContext, Client));
 delete_from_db(DbContext, #chef_node{}=Node) ->
     handle_delete_from_db(chef_db:delete_node(DbContext, Node));
+delete_from_db(DbContext, #chef_user{}=User) ->
+    handle_delete_from_db(chef_db:delete_user(DbContext, User));
 delete_from_db(DbContext, #chef_role{}=Role) ->
     handle_delete_from_db(chef_db:delete_role(DbContext, Role));
 delete_from_db(DbContext, #chef_environment{}=Environment) ->

--- a/src/chef_object_db.erl
+++ b/src/chef_object_db.erl
@@ -44,7 +44,7 @@ add_to_solr(TypeName, Id, OrgId, Ejson) ->
                         | #chef_cookbook_version{}
                         | #chef_user{}) -> ok.
 delete_from_solr(Object) when is_record(Object, chef_cookbook_version);
-                              is_record(Object, chef_data_bag_item);
+                              is_record(Object, chef_data_bag);
                               is_record(Object, chef_user) ->
                  ok; %%These types are not indexed, so don't need to issue delete
 delete_from_solr(Object) ->

--- a/src/chef_object_db.erl
+++ b/src/chef_object_db.erl
@@ -60,10 +60,12 @@ delete_from_solr(Object) ->
 %% pulled out of the db so it will be as if the data was correctly deleted. If we deleted
 %% the solr data when a db error was encountered, we could have data in the db that could
 %% not be findable via search.
--spec delete( chef_db:db_context(),
-    chef_object() | #chef_cookbook_version{checksums::'undefined' | [binary()]},
-    object_id() ) -> ok.
-
+-spec delete(chef_db:db_context(),
+             chef_object() |
+             #chef_cookbook_version{checksums::'undefined' |
+                                               [binary()]} |
+             #chef_user{},
+             object_id() ) -> ok.
 delete(DbContext,#chef_data_bag{org_id = OrgId,
                                 name = DataBagName}=DataBag,
                                 _RequestorId) ->
@@ -138,3 +140,4 @@ get_id_and_org_id(#chef_data_bag_item{id = Id, org_id = OrgId}) ->
     {Id, OrgId};
 get_id_and_org_id(#chef_cookbook_version{id = Id, org_id = OrgId}) ->
     {Id, OrgId}.
+

--- a/src/chef_object_db.erl
+++ b/src/chef_object_db.erl
@@ -32,8 +32,8 @@
 -spec add_to_solr(chef_type(), object_id(), object_id(), ejson_term()) -> ok.
 %% Add a Chef object to solr
 add_to_solr(TypeName, _Id, _OrgId, _Ejson) when TypeName =:= data_bag;
-                                              TypeName =:= user;
-                                              TypeName =:= coookbook_version ->
+                                                TypeName =:= user;
+                                                TypeName =:= coookbook_version ->
             ok; %%These types are not indexed
 add_to_solr(TypeName, Id, OrgId, Ejson) ->
     chef_index_queue:set(TypeName, Id, chef_otto:dbname(OrgId), Ejson).

--- a/src/chef_wm.app.src
+++ b/src/chef_wm.app.src
@@ -24,6 +24,7 @@
                   kernel,
                   stdlib,
                   crypto,
+                  bcrypt,
                   stats_hero,
                   fast_log,
                   sqerl,

--- a/src/chef_wm_authz.erl
+++ b/src/chef_wm_authz.erl
@@ -32,22 +32,25 @@
 
 -include("chef_wm.hrl").
 
-%%
-%% TODO implement is_FOO functions for #chef_user{} when the record
-%% has an 'admin' field
-%%
-
--spec allow_admin(#chef_client{}) -> authorized | forbidden.
+-spec allow_admin(#chef_client{} | #chef_user{}) -> authorized | forbidden.
 allow_admin(#chef_client{admin = true}) ->
     authorized;
 allow_admin(#chef_client{}) ->
+    forbidden;
+allow_admin(#chef_user{admin = true}) ->
+    authorized;
+allow_admin(#chef_user{}) ->
     forbidden.
 
--spec allow_admin_or_requesting_node(#chef_client{}, binary()) -> authorized | forbidden.
+-spec allow_admin_or_requesting_node(#chef_client{} | #chef_user{}, binary()) -> authorized | forbidden.
 allow_admin_or_requesting_node(#chef_client{name = Name}, Name) ->
     authorized;
 allow_admin_or_requesting_node(#chef_client{} = Client, _Name) ->
-    allow_admin(Client).
+    allow_admin(Client);
+allow_admin_or_requesting_node(#chef_user{username = Name}, Name) ->
+    authorized;
+allow_admin_or_requesting_node(#chef_user{} = User, _Name) ->
+    allow_admin(User).
 
 -spec allow_validator(#chef_client{}) -> authorized | forbidden.
 allow_validator(#chef_client{validator = true}) ->

--- a/src/chef_wm_authz.erl
+++ b/src/chef_wm_authz.erl
@@ -28,6 +28,7 @@
          allow_admin_or_requesting_node/2,
          allow_validator/1,
          is_admin/1,
+         is_requesting_node/2,
          is_validator/1]).
 
 -include("chef_wm.hrl").
@@ -58,10 +59,24 @@ allow_validator(#chef_client{validator = true}) ->
 allow_validator(#chef_client{}) ->
     forbidden.
 
--spec is_admin(#chef_client{}) -> true | false.
+-spec is_admin(#chef_client{} | #chef_user{}) -> true | false.
 is_admin(#chef_client{admin = true}) ->
     true;
 is_admin(#chef_client{}) ->
+    false;
+is_admin(#chef_user{admin = true}) ->
+    true;
+is_admin(#chef_user{}) ->
+    false.
+
+-spec is_requesting_node(#chef_client{} | #chef_user{}, binary()) -> true | false.
+is_requesting_node(#chef_client{name = Name}, Name) ->
+    true;
+is_requesting_node(#chef_client{}, _Name) ->
+    false;
+is_requesting_node(#chef_user{username = Name}, Name) ->
+    true;
+is_requesting_node(#chef_user{}, _Name) ->
     false.
 
 -spec is_validator(#chef_client{}) -> true | false.

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -636,8 +636,11 @@ handle_auth_info(chef_wm_named_client, Req, #base_state{requestor = Requestor,
             forbidden
     end;
 handle_auth_info(chef_wm_users, _, _) ->
-  %% temp pass
-  authorized;
+    %% temp pass
+    authorized;
+handle_auth_info(chef_wm_named_user, _, _) ->
+    %% temp pass
+    authorized;
 handle_auth_info(Module, Req, #base_state{requestor = Requestor})
         when Module =:= chef_wm_cookbook_version;
              Module =:= chef_wm_named_environment;

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -635,6 +635,9 @@ handle_auth_info(chef_wm_named_client, Req, #base_state{requestor = Requestor,
         _Else ->
             forbidden
     end;
+handle_auth_info(chef_wm_users, _, _) ->
+  %% temp pass
+  authorized;
 handle_auth_info(Module, Req, #base_state{requestor = Requestor})
         when Module =:= chef_wm_cookbook_version;
              Module =:= chef_wm_named_environment;

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -647,20 +647,60 @@ handle_auth_info(chef_wm_users, Req, #base_state{requestor = Requestor}) ->
     _Else ->
         forbidden
   end;
-handle_auth_info(chef_wm_named_user, Req, #base_state{requestor = Requestor}) ->
+handle_auth_info(chef_wm_named_user, Req, #base_state{requestor = Requestor,
+                                           chef_db_context = DbContext,
+                                           resource_state = #user_state{chef_user = User}}) ->
   UserName = chef_wm_util:object_name(user, Req),
   case wrq:method(Req) of
     'PUT' ->
-      %% Also need to ensure last admin can't make themselves a non-admin
-      chef_wm_authz:allow_admin_or_requesting_node(Requestor, UserName);
+      %% Ensure user can't reset themselves to not be non-admin if none are left
+      case chef_wm_authz:is_admin(Requestor) andalso chef_wm_authz:is_requesting_node(Requestor, UserName) of
+        true ->
+          %%They are an admin and updating themselves
+          case chef_db:count_user_admins(DbContext) >1 of
+            %% They are an admin, are they attempting to change the admin status?
+            true ->
+              case chef_wm_util:admin_field_is_false(User) of
+                 %% They are attempting to change their admin field, deny
+                 true ->
+                   forbidden;
+                 %% They are not attempting to change their admin field, allow
+                 false ->
+                   authorized
+               end;
+            %% More than one admin left, let the operation continue
+            false ->
+              authorized
+          end;
+        false ->
+          %% User is not in danger of setting last to non-admin status
+          chef_wm_authz:allow_admin_or_requesting_node(Requestor, UserName)
+      end;
     'GET' ->
       chef_wm_authz:allow_admin_or_requesting_node(Requestor, UserName);
     'DELETE' ->
-      %% Also need to ensure last admin can't be deleted
-      chef_wm_authz:allow_admin_or_requesting_node(Requestor, UserName);
+      %% Ensure last admin can't be deleted
+      case chef_wm_authz:is_admin(Requestor) andalso chef_wm_authz:is_requesting_node(Requestor, UserName) of
+        %% User is an admin and trying to operate on itself
+        true ->
+          case chef_db:count_user_admins(DbContext) > 1 of
+            %% More than one admin left, let operation continue
+            true ->
+                authorized;
+            %% Last admin, don't let them delete themselves
+            false ->
+                forbidden
+            end;
+        %% User is not in danger of deleting the last admin, check normal permissions
+        false ->
+          chef_wm_authz:allow_admin_or_requesting_node(Requestor, UserName)
+      end;
     _Else ->
       forbidden
   end;
+
+
+
 handle_auth_info(Module, Req, #base_state{requestor = Requestor})
         when Module =:= chef_wm_cookbook_version;
              Module =:= chef_wm_named_environment;

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -285,7 +285,10 @@ create_from_json(#wm_reqdata{} = Req,
             {{halt, 500}, Req, State#base_state{log_msg = What}}
     end.
 
--spec update_from_json(#wm_reqdata{}, #base_state{}, chef_object() | #chef_cookbook_version{}, ejson_term()) ->
+-spec update_from_json(#wm_reqdata{},
+                       #base_state{},
+                       chef_object() | #chef_cookbook_version{} | #chef_user{},
+                       ejson_term()) ->
                               {true, #wm_reqdata{}, #base_state{}} |
                               {{halt, 400 | 404 | 500}, #wm_reqdata{}, #base_state{}}.
 %% @doc Implements the from_json callback for PUT requests to update Chef

--- a/src/chef_wm_named_user.erl
+++ b/src/chef_wm_named_user.erl
@@ -1,0 +1,170 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% @author Seth Falcon <seth@opscode.com>
+%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+
+-module(chef_wm_named_user).
+
+-include("chef_wm.hrl").
+
+-mixin([{chef_wm_base, [content_types_accepted/2,
+                        content_types_provided/2,
+                        finish_request/2,
+                        malformed_request/2,
+                        ping/2,
+                        post_is_create/2]}]).
+
+-mixin([{?BASE_RESOURCE, [forbidden/2,
+                          is_authorized/2,
+                          service_available/2]}]).
+
+%% chef_wm behaviour callbacks
+-behaviour(chef_wm).
+-export([
+         auth_info/2,
+         init/1,
+         init_resource_state/1,
+         malformed_request_message/3,
+         request_type/0,
+         validate_request/3
+        ]).
+
+-export([
+         allowed_methods/2,
+         delete_resource/2,
+         from_json/2,
+         to_json/2
+       ]).
+
+init(Config) ->
+    chef_wm_base:init(?MODULE, Config).
+
+init_resource_state(_Config) ->
+    {ok, #user_state{}}.
+
+request_type() ->
+  "users".
+
+allowed_methods(Req, State) ->
+    {['GET', 'PUT', 'DELETE'], Req, State}.
+
+validate_request(Method, Req, State) when Method == 'GET';
+                                          Method == 'DELETE' ->
+    {Req, State};
+validate_request('PUT', Req, #base_state{resource_state = UserState} = State) ->
+    Name = chef_wm_util:object_name(user, Req),
+    Body = wrq:req_body(Req),
+    %% FIXME: need to validate no name change since we aren't going to support rename for
+    %% users.
+    {ok, User} = chef_user:parse_binary_json(Body, create),
+    {Req, State#base_state{resource_state = UserState#user_state{user_data = User}}}.
+
+auth_info(Req, #base_state{chef_db_context = DbContext,
+                           resource_state = UserState,
+                           organization_name=OrgName}=State) ->
+    UserName = chef_wm_util:object_name(user, Req),
+    case chef_db:fetch_user(DbContext, UserName) of
+        not_found ->
+            Message = chef_wm_util:not_found_message(user, UserName),
+            Req1 = chef_wm_util:set_json_body(Req, Message),
+            {{halt, 404}, Req1, State#base_state{log_msg = user_not_found}};
+        #chef_user{authz_id = AuthzId} = User ->
+            UserState1 = UserState#user_state{chef_user = User},
+            State1 = State#base_state{resource_state = UserState1},
+            {{object, AuthzId}, Req, State1}
+    end.
+
+from_json(Req, #base_state{reqid = RequestId,
+                           resource_state =
+                               #user_state{chef_user = User,
+                                             user_data = UserData}} = State) ->
+    UserData1 = maybe_generate_key_pair(UserData, RequestId),
+    chef_wm_base:update_from_json(Req, State, User, UserData1).
+
+to_json(Req, #base_state{resource_state =
+                             #user_state{chef_user = User},
+                         organization_name = OrgName} = State) ->
+    EJson = chef_user:assemble_user_ejson(User, OrgName),
+    Json = ejson:encode(EJson),
+    {Json, Req, State}.
+
+delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 requestor_id = RequestorId,
+                                 resource_state = #user_state{
+                                   chef_user = User},
+                                 organization_name = OrgName} = State) ->
+    ok = chef_object_db:delete(DbContext, User, RequestorId),
+    EJson = chef_user:assemble_user_ejson(User, OrgName),
+    Req1 = chef_wm_util:set_json_body(Req, EJson),
+    {true, Req1, State}.
+
+%% If the request contains "private_key":true, then we will generate a new key pair. In
+%% this case, we'll add the new public and private keys into the EJSON since
+%% update_from_json will use it to set the response.
+maybe_generate_key_pair(UserData, RequestId) ->
+    Name = ej:get({<<"name">>}, UserData),
+    case ej:get({<<"private_key">>}, UserData) of
+        true ->
+            {PublicKey, PrivateKey} = chef_wm_util:generate_keypair(Name, RequestId),
+            chef_user:set_key_pair(UserData,
+                                   {public_key, PublicKey},
+                                   {private_key, PrivateKey});
+        _ ->
+            UserData
+    end.
+
+% TODO: this could stand refactoring: I'm sure there is stuff re-used by other
+% endpoints and possibly unused code here
+error_message(Msg) when is_list(Msg) ->
+    error_message(iolist_to_binary(Msg));
+error_message(Msg) when is_binary(Msg) ->
+    {[{<<"error">>, [Msg]}]}.
+
+malformed_request_message(#ej_invalid{type = json_type, key = Key}, _Req, _State) ->
+    case Key of
+        undefined -> error_message([<<"Incorrect JSON type for request body">>]);
+        _ ->error_message([<<"Incorrect JSON type for ">>, Key])
+    end;
+malformed_request_message(#ej_invalid{type = missing, key = Key}, _Req, _State) ->
+    error_message([<<"Required value for ">>, Key, <<" is missing">>]);
+malformed_request_message({invalid_key, Key}, _Req, _State) ->
+    error_message([<<"Invalid key ">>, Key, <<" in request body">>]);
+malformed_request_message(invalid_json_body, _Req, _State) ->
+    error_message([<<"Incorrect JSON type for request body">>]);
+malformed_request_message(#ej_invalid{type = exact, key = Key, msg = Expected},
+                          _Req, _State) ->
+    error_message([Key, <<" must equal ">>, Expected]);
+malformed_request_message(#ej_invalid{type = string_match, msg = Error},
+                          _Req, _State) ->
+    error_message([Error]);
+malformed_request_message(#ej_invalid{type = object_key, key = Object, found = Key},
+                          _Req, _State) ->
+    error_message([<<"Invalid key '">>, Key, <<"' for ">>, Object]);
+% TODO: next two tests can get merged (hopefully) when object_map is extended not
+% to swallow keys
+malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
+                          _Req, _State) when is_binary(Val) ->
+    error_message([<<"Invalid value '">>, Val, <<"' for ">>, Object]);
+malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
+                          _Req, _State) ->
+    error_message([<<"Invalid value '">>, io_lib:format("~p", [Val]),
+                   <<"' for ">>, Object]);
+malformed_request_message(Any, _Req, _State) ->
+    error({unexpected_malformed_request_message, Any}).
+

--- a/src/chef_wm_named_user.erl
+++ b/src/chef_wm_named_user.erl
@@ -105,13 +105,12 @@ to_json(Req, #base_state{resource_state =
     Json = ejson:encode(EJson),
     {Json, Req, State}.
 
-delete_resource(Req, #base_state{%% chef_db_context = DbContext,
-                                 %% requestor_id = RequestorId,
+delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 requestor_id = RequestorId,
                                  resource_state = #user_state{
                                    chef_user = User},
                                  organization_name = OrgName} = State) ->
-    %% FIXME: need to implement delete in chef_db
-    %% ok = chef_object_db:delete(DbContext, User, RequestorId),
+    ok = chef_object_db:delete(DbContext, User, RequestorId),
     EJson = chef_user:assemble_user_ejson(User, OrgName),
     Req1 = chef_wm_util:set_json_body(Req, EJson),
     {true, Req1, State}.

--- a/src/chef_wm_named_user.erl
+++ b/src/chef_wm_named_user.erl
@@ -72,7 +72,7 @@ validate_request('PUT', Req, #base_state{resource_state = UserState} = State) ->
     Body = wrq:req_body(Req),
     %% FIXME: need to validate no name change since we aren't going to support rename for
     %% users.
-    {ok, User} = chef_user:parse_binary_json(Body, create),
+    {ok, User} = chef_user:parse_binary_json(Body),
     {Req, State#base_state{resource_state = UserState#user_state{user_data = User}}}.
 
 auth_info(Req, #base_state{chef_db_context = DbContext,

--- a/src/chef_wm_routes.erl
+++ b/src/chef_wm_routes.erl
@@ -42,7 +42,8 @@ bulk_route_fun(Type, Req) when Type =:= role;
                                Type =:= environment;
                                Type =:= client;
                                Type =:= data_bag;
-                               Type =:= data_bag_item ->
+                               Type =:= data_bag_item;
+                               Type =:= user ->
     BaseURI = chef_wm_util:base_uri(Req),
     Template = template_for_type(Type),
     fun(Name) ->
@@ -135,7 +136,9 @@ template_for_type(data_bag_item) ->
     "/data/~s/~s";
 template_for_type({data_bag, _}) ->
     %% another way of asking for data_bag_item
-    "/data/~s/~s".
+    "/data/~s/~s";
+template_for_type(user) ->
+    "/users/~s".
 
 %% This is extracted from search, needs more cleanup
 url_for_search_item_fun(Req, Type, _OrgName) ->

--- a/src/chef_wm_routes.erl
+++ b/src/chef_wm_routes.erl
@@ -80,6 +80,7 @@ route(organization_search, Req, Args) ->
 %% Create a url for an individual role.  Requires a 'role_name' argument
 route(node, Req, Args) -> route_rest_object("nodes", Req, Args);
 route(role, Req, Args) -> route_rest_object("roles", Req, Args);
+route(user, Req, Args) -> route_rest_object("users", Req, Args);
 route(data_bag, Req, Args) -> route_rest_object("data", Req, Args);
 route(environment, Req, Args) -> route_rest_object("environments", Req, Args);
 route(client, Req, Args) -> route_rest_object("clients", Req, Args);

--- a/src/chef_wm_users.erl
+++ b/src/chef_wm_users.erl
@@ -94,7 +94,6 @@ from_json(Req, #base_state{reqid = RequestId,
             Else
     end.
 
-%% Need to write function to be called here
 to_json(Req, State) ->
     {all_users_json(Req, State), Req, State}.
 

--- a/src/chef_wm_users.erl
+++ b/src/chef_wm_users.erl
@@ -161,12 +161,12 @@ malformed_request_message(invalid_json_body, _Req, _State) ->
 malformed_request_message(#ej_invalid{type = exact, key = Key, msg = Expected},
                           _Req, _State) ->
     error_message([Key, <<" must equal ">>, Expected]);
+malformed_request_message(#ej_invalid{type = fun_match, key = Key, msg = Error},
+                          _Req, _State) when Key =:= <<"password">> ->
+    error_message([Error]);
 malformed_request_message(#ej_invalid{type = string_match, key = Key, msg = Error},
                           _Req, _State) ->
-    case Key of
-        <<"password">> -> error_message([<<"Password must have at least 6 characters">>]);
-        _ -> error_message([Error])
-    end;
+    error_message([Error]);
 malformed_request_message(#ej_invalid{type = object_key, key = Object, found = Key},
                           _Req, _State) ->
     error_message([<<"Invalid key '">>, Key, <<"' for ">>, Object]);

--- a/src/chef_wm_users.erl
+++ b/src/chef_wm_users.erl
@@ -47,10 +47,15 @@ request_type() ->
 allowed_methods(Req, State) ->
   {['POST'], Req, State}.
 
-validate_request('POST', Req, #base_state{resource_state = UserState} = State) ->
-  Body = wrq:req_body(Req),
-  {ok, UserData} = chef_user:parse_binary_json(Body, create),
-  {Req, State#base_state{resource_state = UserState#user_state{user_data = UserData}}}.
+validate_request('POST', Req, State) ->
+  case wrq:req_body(Req) of
+    undefined ->
+      throw({error, missing_body});
+   Body ->
+      {ok, UserData} = chef_user:parse_binary_json(Body, create),
+      {Req, State#base_state{resource_state =
+          #user_state{user_data = UserData}}}
+  end.
 
 %% Create, destroy, and update are admin only actions
 %% Need to update this to reflect that, as right now it

--- a/src/chef_wm_users.erl
+++ b/src/chef_wm_users.erl
@@ -77,33 +77,23 @@ create_path(Req, #base_state{resource_state = #user_state{user_data = UserData}}
 from_json(Req, #base_state{reqid = RequestId,
                            resource_state = #user_state{user_data = UserData,
                            user_authz_id = AuthzId}} = State) ->
-  %% FIXME: This code closely mirrors that of client and can likely be extracted out
-  Name = ej:get({<<"name">>}, UserData),
-  {PublicKey, PrivateKey} = chef_wm_util:generate_keypair(Name, RequestId),
-  UserData1 = chef_user:set_public_key(UserData, PublicKey),
-  UserData2 = secure_password(UserData1),
-  case chef_wm_base:create_from_json(Req, State, chef_user, {authz_id, AuthzId}, UserData2) of
-    {true, Req1, State1} ->
-      Uri = list_to_binary(chef_wm_util:full_uri(Req1)),
-      Ejson = {[{<<"uri">>, Uri},
-                {<<"private_key">>, PrivateKey},
-                {<<"public_key">>, PublicKey}
-               ]},
-      {true, chef_wm_util:set_json_body(Req1, Ejson), State1};
-    Else ->
-      Else
-  end.
-
-secure_password(User) ->
-  _Password = ej:get({<<"password">>}, User),
- %% Password gets passed to the password module here
- %% Assuming return type from password module, will need to adjust
- %% Using hard coded values for now
- {HashedPassword, Salt, HashType} = {<<"hidden">>, <<"kosher">>, <<"thegoodkind">>},
- User1 = ej:set({<<"password">>}, User, HashedPassword),
- User2 = ej:set({<<"salt">>}, User1, Salt),
- User3 = ej:set({<<"hash_type">>}, User2, HashType),
- User3.
+    Name = ej:get({<<"name">>}, UserData),
+    {PublicKey, PrivateKey} = chef_wm_util:generate_keypair(Name, RequestId),
+    UserWithKey = chef_user:set_public_key(UserData, PublicKey),
+    PasswordData = chef_wm_password:encrypt(ej:get({<<"password">>}, UserWithKey)),
+    case chef_wm_base:create_from_json(Req, State, chef_user,
+                                       {authz_id, AuthzId},
+                                       {UserWithKey, PasswordData}) of
+        {true, Req1, State1} ->
+            Uri = list_to_binary(chef_wm_util:full_uri(Req1)),
+            Ejson = {[{<<"uri">>, Uri},
+                      {<<"private_key">>, PrivateKey},
+                      {<<"public_key">>, PublicKey}
+                     ]},
+            {true, chef_wm_util:set_json_body(Req1, Ejson), State1};
+        Else ->
+            Else
+    end.
 
 %% Need to write function to be called here
 to_json(Req, State) ->

--- a/src/chef_wm_users.erl
+++ b/src/chef_wm_users.erl
@@ -105,10 +105,6 @@ all_users_json(Req, #base_state{chef_db_context = DbContext}) ->
     UriMap = [ {Name, RouteFun(Name)} || Name <- UserNames ],
     ejson:encode({UriMap}).
 
-
-malformed_request_message(Any, _Req, _State) ->
-    error({unexpected_malformed_request_message, Any}).
-
 %% FIXME: we will likely be able to re-use something from chef_wm_base once a bit of
 %% refaactoring happens. This is largely copy pasta from chef_wm_base, but with solr bits
 %% removed.
@@ -146,3 +142,40 @@ maybe_authz_id(B) ->
 conflict_message(Name) ->
     Msg = iolist_to_binary([<<"User '">>, Name, <<"' already exists">>]),
     {[{<<"error">>, [Msg]}]}.
+
+error_message(Msg) when is_list(Msg) ->
+    error_message(iolist_to_binary(Msg));
+error_message(Msg) when is_binary(Msg) ->
+    {[{<<"error">>, [Msg]}]}.
+
+malformed_request_message(#ej_invalid{type = json_type, key = Key}, _Req, _State) ->
+    case Key of
+        undefined -> error_message([<<"Incorrect JSON type for request body">>]);
+        _ ->error_message([<<"Incorrect JSON type for ">>, Key])
+    end;
+malformed_request_message(#ej_invalid{type = missing, key = Key}, _Req, _State) ->
+    error_message([<<"Required value for ">>, Key, <<" is missing">>]);
+malformed_request_message({invalid_key, Key}, _Req, _State) ->
+    error_message([<<"Invalid key ">>, Key, <<" in request body">>]);
+malformed_request_message(invalid_json_body, _Req, _State) ->
+    error_message([<<"Incorrect JSON type for request body">>]);
+malformed_request_message(#ej_invalid{type = exact, key = Key, msg = Expected},
+                          _Req, _State) ->
+    error_message([Key, <<" must equal ">>, Expected]);
+malformed_request_message(#ej_invalid{type = string_match, msg = Error},
+                          _Req, _State) ->
+    error_message([Error]);
+malformed_request_message(#ej_invalid{type = object_key, key = Object, found = Key},
+                          _Req, _State) ->
+    error_message([<<"Invalid key '">>, Key, <<"' for ">>, Object]);
+% TODO: next two tests can get merged (hopefully) when object_map is extended not
+% to swallow keys
+malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
+                          _Req, _State) when is_binary(Val) ->
+    error_message([<<"Invalid value '">>, Val, <<"' for ">>, Object]);
+malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
+                          _Req, _State) ->
+    error_message([<<"Invalid value '">>, io_lib:format("~p", [Val]),
+                   <<"' for ">>, Object]);
+malformed_request_message(Any, Req, State) ->
+    chef_wm_util:malformed_request_message(Any, Req, State).

--- a/src/chef_wm_users.erl
+++ b/src/chef_wm_users.erl
@@ -52,7 +52,7 @@ validate_request('POST', Req, State) ->
     undefined ->
       throw({error, missing_body});
    Body ->
-      {ok, UserData} = chef_user:parse_binary_json(Body, create),
+      {ok, UserData} = chef_user:parse_binary_json(Body),
       {Req, State#base_state{resource_state =
           #user_state{user_data = UserData}}}
   end;

--- a/src/chef_wm_users.erl
+++ b/src/chef_wm_users.erl
@@ -161,9 +161,12 @@ malformed_request_message(invalid_json_body, _Req, _State) ->
 malformed_request_message(#ej_invalid{type = exact, key = Key, msg = Expected},
                           _Req, _State) ->
     error_message([Key, <<" must equal ">>, Expected]);
-malformed_request_message(#ej_invalid{type = string_match, msg = Error},
+malformed_request_message(#ej_invalid{type = string_match, key = Key, msg = Error},
                           _Req, _State) ->
-    error_message([Error]);
+    case Key of
+        <<"password">> -> error_message([<<"Password must have at least 6 characters">>]);
+        _ -> error_message([Error])
+    end;
 malformed_request_message(#ej_invalid{type = object_key, key = Object, found = Key},
                           _Req, _State) ->
     error_message([<<"Invalid key '">>, Key, <<"' for ">>, Object]);

--- a/src/chef_wm_users.erl
+++ b/src/chef_wm_users.erl
@@ -1,0 +1,78 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Mark Mzyk <mmzyk@opscode.com>
+%% @copyright 2012 Opscode, Inc.
+
+%% @doc Resource module for Chef users endpoint
+
+-module(chef_wm_users).
+
+-include("chef_wm.hrl").
+
+-mixin([{chef_wm_base, [content_types_accepted/2,
+                        content_types_provided/2,
+                        finish_request/2,
+                        malformed_request/2,
+                        ping/2,
+                        post_is_create/2]}]).
+
+-mixin([{?BASE_RESOURCE, [forbidden/2,
+                          is_authorized/2,
+                          service_available/2]}]).
+
+-behavior(chef_wm).
+-export([auth_info/2,
+         init/1,
+         init_resource_state/1,
+         malformed_request_message/3,
+         request_type/0,
+         validate_request/3]).
+
+-export([allowed_methods/2,
+         create_path/2,
+         from_json/2,
+         resource_exists/2,
+         to_json/2]).
+
+init(Config) ->
+  chef_wm_base:init(?MODULE, Config).
+
+%% Need to add the user_state
+init_resource_state(_Config) ->
+  {ok, #user_state{}}.
+
+request_type() ->
+  "users".
+
+allowed_methods(Req, State) ->
+  {['POST'], Req, State}.
+
+validate_request('POST', Req, #base_state{resource_state = UserState} = State) ->
+  Body = wrq:req_body(Req),
+  {ok, UserData} = chef_user:parse_binary_json(Body, create),
+  {Req, State#base_state{resource_state = UserState#user_state{user_data = UserData}}}.
+
+%% Create, destroy, and update are admin only actions
+%% Need to update this to reflect that, as right now it
+%% lets anyone through.
+auth_info(Req, State) ->
+  {authorized, Req, State}.
+
+%% If we get here, are we guarenteed the user exists?
+resource_exists(Req, State) ->
+  {true, Req, State}.
+
+%% What is the purpose of this method?
+create_path(Req, #base_state{resource_state = #user_state{user_data = UserData}} = State) ->
+  Name = ej:get({<<"name">>}, UserData),
+  {binary_to_list(Name), Req, State}.
+
+from_json(Req, #base_state{resource_state = #user_state{user_data = UserData, user_authz_id = AuthzId}} = State) ->
+  chef_wm_base:create_from_json(Req, State, chef_user, {authz_id, AuthzId}, UserData).
+
+%% Need to write function to be called here
+to_json(Req, State) ->
+  filler.
+
+malformed_request_message(Any, _Req, _State) ->
+    error({unexpected_malformed_request_message, Any}).

--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -84,8 +84,10 @@ environment_not_found_message(EnvName) ->
 %% TODO: Why are these messages phrased differently?  This is what the Ruby endpoints were
 %% doing, FYI.  Is this something we're stuck with, or can we update the API and normalize
 %% these messages?
--spec not_found_message( node | role | data_bag | data_bag_item1 | data_bag_item2 | client
-                         | data_bag_missing_for_item_post | environment | sandbox | sandboxes | cookbook | cookbook_version,
+-spec not_found_message( node | role | data_bag | data_bag_item1 |
+                         data_bag_item2 | client | data_bag_missing_for_item_post |
+                         environment | sandbox | sandboxes | cookbook |
+                         cookbook_version | user,
                          bin_or_string() | {bin_or_string(), bin_or_string()} ) -> ejson().
 not_found_message(node, Name) ->
     error_message_envelope(iolist_to_binary(["node '", Name, "' not found"]));

--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -172,7 +172,7 @@ set_uri_of_created_resource(Uri, Req0) when is_binary(Uri) ->
 %% TODO: Currently we only use this for nodes and roles; when we clean up our custom types,
 %% the spec will be updated
 -spec object_name(cookbook | node | role | data_bag | data_bag_item |
-                  environment | sandbox | client,
+                  environment | sandbox | client | user,
                   Request :: #wm_reqdata{}) -> binary() | undefined.
 object_name(node, Req) ->
     extract_from_path(node_name, Req);

--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -28,6 +28,8 @@
          extract_from_path/2,
          full_uri/1,
          get_header_fun/2,
+         malformed_request_message/3,
+         admin_field_is_false/1,
          base_mods/0,
          not_found_message/2,
          num_versions/1,
@@ -204,6 +206,48 @@ extract_from_path(PathKey, Req) ->
         Value ->
             list_to_binary(Value)
     end.
+
+error_message(Msg) when is_list(Msg) ->
+    error_message(iolist_to_binary(Msg));
+error_message(Msg) when is_binary(Msg) ->
+    {[{<<"error">>, [Msg]}]}.
+
+malformed_request_message(#ej_invalid{type = json_type, key = Key}, _Req, _State) ->
+    case Key of
+        undefined -> error_message([<<"Incorrect JSON type for request body">>]);
+        _ ->error_message([<<"Incorrect JSON type for ">>, Key])
+    end;
+malformed_request_message(#ej_invalid{type = missing, key = Key}, _Req, _State) ->
+    error_message([<<"Required value for ">>, Key, <<" is missing">>]);
+malformed_request_message({invalid_key, Key}, _Req, _State) ->
+    error_message([<<"Invalid key ">>, Key, <<" in request body">>]);
+malformed_request_message(invalid_json_body, _Req, _State) ->
+    error_message([<<"Incorrect JSON type for request body">>]);
+malformed_request_message(#ej_invalid{type = exact, key = Key, msg = Expected},
+                          _Req, _State) ->
+    error_message([Key, <<" must equal ">>, Expected]);
+malformed_request_message(#ej_invalid{type = string_match, msg = Error},
+                          _Req, _State) ->
+    error_message([Error]);
+malformed_request_message(#ej_invalid{type = object_key, key = Object, found = Key},
+                          _Req, _State) ->
+    error_message([<<"Invalid key '">>, Key, <<"' for ">>, Object]);
+% TODO: next two tests can get merged (hopefully) when object_map is extended not
+% to swallow keys
+malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
+                          _Req, _State) when is_binary(Val) ->
+    error_message([<<"Invalid value '">>, Val, <<"' for ">>, Object]);
+malformed_request_message(#ej_invalid{type = object_value, key = Object, found = Val},
+                          _Req, _State) ->
+    error_message([<<"Invalid value '">>, io_lib:format("~p", [Val]),
+                   <<"' for ">>, Object]);
+malformed_request_message(Any, _Req, _State) ->
+    error({unexpected_malformed_request_message, Any}).
+
+admin_field_is_false(#chef_user{admin = Admin}) when Admin =:= false ->
+  true;
+admin_field_is_false(#chef_user{}) ->
+  false.
 
 %% @doc Utility function to process the `num_versions' parameter that is common to several
 %% cookbook-related resources

--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -114,7 +114,10 @@ not_found_message(cookbook, Name) when is_binary(Name) ->
 not_found_message(cookbook_version, {Name, Version}) when is_binary(Version) -> %% NOT a parsed {Major, Minor, Patch} tuple!!
     error_message_envelope(iolist_to_binary(["Cannot find a cookbook named ", Name, " with version ", Version]));
 not_found_message(client, Name) ->
-    error_message_envelope(iolist_to_binary(["Cannot load client ", Name])).
+    error_message_envelope(iolist_to_binary(["Cannot load client ", Name]));
+not_found_message(user, Name) ->
+    error_message_envelope(iolist_to_binary(["user '", Name, "' not found"])).
+
 
 %% "Cannot load data bag item not_really_there for data bag sack"
 
@@ -186,7 +189,9 @@ object_name(environment, Req) ->
 object_name(cookbook, Req) ->
     extract_from_path(cookbook_name, Req);
 object_name(client, Req) ->
-    extract_from_path(client_name, Req).
+    extract_from_path(client_name, Req);
+object_name(user, Req) ->
+    extract_from_path(user_name, Req).
 
 %% @doc Private utility function to extract a path element as a binary.  Returns the atom
 %% `undefined' if no such value exists.


### PR DESCRIPTION
@seth I am opening this pull request because I'd like you to look at the last commit from 10/1. It contains the logic that attempts to prevent a user from deleting the last admin client. It's somewhat involved and I think with more love it could be made cleaner.

That said: there is one giant whole right now: it won't stop a client from making a request to delete the admin user. I don't know how big an issue this is, but I discovered it because in testing from shef the user is a client user and so the logic wasn't preventing the requests from deleting the last admin user.

Let me know what you thin.
