### PR TITLE
Assorted Client Cleanups

### DIFF
--- a/src/chef_wm_named_client.erl
+++ b/src/chef_wm_named_client.erl
@@ -59,7 +59,7 @@ init_resource_state(_Config) ->
     {ok, #client_state{}}.
 
 request_type() ->
-  "data".
+  "clients".
 
 allowed_methods(Req, State) ->
     {['GET', 'PUT', 'DELETE'], Req, State}.

--- a/src/chef_wm_routes.erl
+++ b/src/chef_wm_routes.erl
@@ -155,8 +155,6 @@ url_for_search_item_fun(Req, Type, _OrgName) ->
 
 make_args(Item, {data_bag, Bag}) ->
     [Bag, data_bag_item_id(Item)];
-make_args(Item, client) ->
-    [ej:get({<<"clientname">>}, Item)];
 make_args(Item, _) ->
     [ej:get({<<"name">>}, Item)].
 


### PR DESCRIPTION
Cleans up a handful of testing operations around clients.

Fixes a bug in chef_wm which prevented partial searches for clients.

Normalizes the client creation code in chef-pedant-core to mirror
similar code for other objects.

Takes advantage of those changes to add partial search tests for
clients to chef-pedant-tests.
