### PR TITLE
OC-2560: Validator Lockdown

### DIFF
--- a/src/chef_wm_authz.erl
+++ b/src/chef_wm_authz.erl
@@ -28,7 +28,6 @@
          all_but_validators/1,
          allow_admin/1,
          allow_admin_or_requesting_node/2,
-         allow_validator/1,
          is_admin/1,
          is_requesting_node/2,
          is_validator/1]).
@@ -68,12 +67,6 @@ allow_admin_or_requesting_node(#chef_user{username = Name}, Name) ->
 allow_admin_or_requesting_node(#chef_user{} = User, _Name) ->
     allow_admin(User).
 
--spec allow_validator(#chef_client{}) -> authorized | forbidden.
-allow_validator(#chef_client{validator = true}) ->
-    authorized;
-allow_validator(#chef_client{}) ->
-    forbidden.
-
 -spec is_admin(#chef_client{} | #chef_user{}) -> true | false.
 is_admin(#chef_client{admin = true}) ->
     true;
@@ -99,5 +92,3 @@ is_validator(#chef_client{validator = true}) ->
     true;
 is_validator(#chef_client{}) ->
     false.
-
-

--- a/src/chef_wm_authz.erl
+++ b/src/chef_wm_authz.erl
@@ -34,61 +34,44 @@
 
 -include("chef_wm.hrl").
 
-%% @doc Rejects validator clients, but allows all other requestors.
+%% @doc Reject validator clients, but allow all other requestors.
 all_but_validators(#chef_client{validator=true}) -> forbidden;
 all_but_validators(#chef_client{})               -> authorized;
 all_but_validators(#chef_user{})                 -> authorized.
 
--spec allow_admin(#chef_client{} | #chef_user{}) -> authorized | forbidden.
+%% @doc Only authorize admin requestors.
+%%
 %% Technically, it is possible for a client to be both validator and admin... this should
-%% probably be disallowed
-allow_admin(#chef_client{validator = true}) ->
-    forbidden;
-allow_admin(#chef_client{admin = true}) ->
-    authorized;
-allow_admin(#chef_client{}) ->
-    forbidden;
-allow_admin(#chef_user{admin = true}) ->
-    authorized;
-allow_admin(#chef_user{}) ->
-    forbidden.
+%% probably be disallowed.
+allow_admin(#chef_client{validator = true}) -> forbidden;
+allow_admin(#chef_client{admin = true})     -> authorized;
+allow_admin(#chef_client{})                 -> forbidden;
+allow_admin(#chef_user{admin = true})       -> authorized;
+allow_admin(#chef_user{})                   -> forbidden.
 
+%% @doc Admins can do what they wish, but other requestors can only proceed if they are
+%% operating on themselves.
+%%
+%% Validators can only create new clients, and cannot even operate on themselves; if you
+%% need to modify a validator for some reason, do it as a proper admin
 -spec allow_admin_or_requesting_node(#chef_client{} | #chef_user{}, binary()) -> authorized | forbidden.
-allow_admin_or_requesting_node(#chef_client{validator = true}, _Name) ->
-    %% Validators can only create new clients, and cannot even operate on themselves; If you
-    %% need to modify a validator for some reason, do it as a proper admin.
-    forbidden;
-allow_admin_or_requesting_node(#chef_client{name = Name}, Name) ->
-    authorized;
-allow_admin_or_requesting_node(#chef_client{} = Client, _Name) ->
-    allow_admin(Client);
-allow_admin_or_requesting_node(#chef_user{username = Name}, Name) ->
-    authorized;
-allow_admin_or_requesting_node(#chef_user{} = User, _Name) ->
-    allow_admin(User).
+allow_admin_or_requesting_node(#chef_client{validator = true}, _Name) -> forbidden;
+allow_admin_or_requesting_node(#chef_client{name = Name}, Name)       -> authorized;
+allow_admin_or_requesting_node(#chef_client{} = Client, _Name)        -> allow_admin(Client);
+allow_admin_or_requesting_node(#chef_user{username = Name}, Name)     -> authorized;
+allow_admin_or_requesting_node(#chef_user{} = User, _Name)            -> allow_admin(User).
 
--spec is_admin(#chef_client{} | #chef_user{}) -> true | false.
-is_admin(#chef_client{admin = true}) ->
-    true;
-is_admin(#chef_client{}) ->
-    false;
-is_admin(#chef_user{admin = true}) ->
-    true;
-is_admin(#chef_user{}) ->
-    false.
+is_admin(#chef_client{admin = true}) -> true;
+is_admin(#chef_client{})             -> false;
+is_admin(#chef_user{admin = true})   -> true;
+is_admin(#chef_user{})               -> false.
 
+%% @doc Is the requestor operating on itself?
 -spec is_requesting_node(#chef_client{} | #chef_user{}, binary()) -> true | false.
-is_requesting_node(#chef_client{name = Name}, Name) ->
-    true;
-is_requesting_node(#chef_client{}, _Name) ->
-    false;
-is_requesting_node(#chef_user{username = Name}, Name) ->
-    true;
-is_requesting_node(#chef_user{}, _Name) ->
-    false.
+is_requesting_node(#chef_client{name = Name}, Name)   -> true;
+is_requesting_node(#chef_client{}, _Name)             -> false;
+is_requesting_node(#chef_user{username = Name}, Name) -> true;
+is_requesting_node(#chef_user{}, _Name)               -> false.
 
--spec is_validator(#chef_client{}) -> true | false.
-is_validator(#chef_client{validator = true}) ->
-    true;
-is_validator(#chef_client{}) ->
-    false.
+is_validator(#chef_client{validator = true}) -> true;
+is_validator(#chef_client{})                 -> false.

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -609,7 +609,7 @@ handle_auth_info(chef_wm_clients, Req,
             IsAdmin = chef_wm_authz:is_admin(Requestor),
 
             IsValidator = chef_wm_authz:is_validator(Requestor),
-            CreatingUnprivileged = (ej:get({<<"admin">>}, Client) =:= false) and
+            CreatingUnprivileged = (ej:get({<<"admin">>}, Client) =:= false) andalso
                 (ej:get({<<"validator">>}, Client) =:= false),
 
             %% Admins can create whatever they want, but validators can only create

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -629,19 +629,11 @@ handle_auth_info(chef_wm_named_client, Req, #base_state{requestor = Requestor,
                                                             #client_state{chef_client = Client}}) ->
     ClientName = chef_wm_util:object_name(client, Req),
     case wrq:method(Req) of
-        'PUT' -> %% update
+        'PUT' ->
             chef_wm_authz:allow_admin(Requestor);
-        'GET' -> %% show
+        Method when Method =:= 'GET';
+                    Method =:= 'DELETE' ->
             chef_wm_authz:allow_admin_or_requesting_node(Requestor, ClientName);
-        'DELETE' -> %% delete
-            case chef_wm_authz:is_validator(Client) of
-                true ->
-                    %% We can't delete the validator
-                    %% Note: this assumes there is only a single validator
-                    forbidden;
-                _Else ->
-                    chef_wm_authz:allow_admin_or_requesting_node(Requestor, ClientName)
-            end;
         _Else ->
             forbidden
     end;

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -606,10 +606,16 @@ handle_auth_info(chef_wm_clients, Req,
                              resource_state = #client_state{client_data = Client}}) ->
     case wrq:method(Req) of
         'POST' -> %% create
-            NotCreatingAdmin = ej:get({<<"admin">>}, Client) =/= true,
             IsAdmin = chef_wm_authz:is_admin(Requestor),
+
             IsValidator = chef_wm_authz:is_validator(Requestor),
-            case IsAdmin orelse (IsValidator andalso NotCreatingAdmin) of
+            CreatingUnprivileged = (ej:get({<<"admin">>}, Client) =:= false) and
+                (ej:get({<<"validator">>}, Client) =:= false),
+
+            %% Admins can create whatever they want, but validators can only create
+            %% non-admin, non-validator clients
+            case IsAdmin orelse
+                (IsValidator andalso CreatingUnprivileged) of
                 true -> authorized;
                 false -> forbidden
             end;
@@ -628,9 +634,10 @@ handle_auth_info(chef_wm_named_client, Req, #base_state{requestor = Requestor,
         'GET' -> %% show
             chef_wm_authz:allow_admin_or_requesting_node(Requestor, ClientName);
         'DELETE' -> %% delete
-            #chef_client{validator = IsValidator} = Client,
-            case IsValidator of
-                true -> %% We can't delete the validator
+            case chef_wm_authz:is_validator(Client) of
+                true ->
+                    %% We can't delete the validator
+                    %% Note: this assumes there is only a single validator
                     forbidden;
                 _Else ->
                     chef_wm_authz:allow_admin_or_requesting_node(Requestor, ClientName)
@@ -700,7 +707,7 @@ handle_auth_info(Module, Req, #base_state{requestor = Requestor})
              Module =:= chef_wm_named_data_item ->
     case wrq:method(Req) of
         'GET' ->
-            authorized;
+            chef_wm_authz:all_but_validators(Requestor);
         'PUT' -> %% update
             chef_wm_authz:allow_admin(Requestor);
         'DELETE' ->
@@ -715,7 +722,7 @@ handle_auth_info(Module, Req, #base_state{requestor = Requestor})
              Module =:= chef_wm_sandboxes ->
     case wrq:method(Req) of
         'GET' ->
-            authorized;
+            chef_wm_authz:all_but_validators(Requestor);
         'POST' -> %% create
             chef_wm_authz:allow_admin(Requestor);
         _Else ->
@@ -724,7 +731,7 @@ handle_auth_info(Module, Req, #base_state{requestor = Requestor})
 handle_auth_info(chef_wm_named_data, Req, #base_state{requestor = Requestor}) ->
     case wrq:method(Req) of
         'GET' ->
-            authorized;
+            chef_wm_authz:all_but_validators(Requestor);
         'POST' -> %% create data_item
             chef_wm_authz:allow_admin(Requestor);
         'DELETE' -> %% delete data
@@ -736,7 +743,7 @@ handle_auth_info(chef_wm_named_node, Req, #base_state{requestor = Requestor}) ->
     NodeName = chef_wm_util:object_name(node, Req),
     case wrq:method(Req) of
         'GET' ->
-            authorized;
+            chef_wm_authz:all_but_validators(Requestor);
         'PUT' -> %% update
             chef_wm_authz:allow_admin_or_requesting_node(Requestor, NodeName);
         'DELETE' -> %% delete
@@ -744,35 +751,46 @@ handle_auth_info(chef_wm_named_node, Req, #base_state{requestor = Requestor}) ->
         _Else ->
             forbidden
     end;
-handle_auth_info(Module, Req, _State)
+handle_auth_info(Module, Req, #base_state{requestor = Requestor})
         when Module =:= chef_wm_nodes;
              Module =:= chef_wm_search ->
     case wrq:method(Req) of
         'GET' ->
-            authorized;
+            chef_wm_authz:all_but_validators(Requestor);
         'POST' ->
-            authorized;
+            chef_wm_authz:all_but_validators(Requestor);
         _Else ->
             forbidden
     end;
-handle_auth_info(Module, Req, _State)
+handle_auth_info(Module, Req, #base_state{requestor = Requestor})
         when Module =:= chef_wm_cookbooks;
              Module =:= chef_wm_environment_cookbooks;
              Module =:= chef_wm_environment_recipes;
              Module =:= chef_wm_environment_roles;
              Module =:= chef_wm_search_index;
-             Module =:= chef_wm_named_principal;
              Module =:= chef_wm_status ->
+    case wrq:method(Req) of
+        'GET' ->
+            chef_wm_authz:all_but_validators(Requestor);
+        _Else ->
+            forbidden
+    end;
+
+%% The named principal endpoint currently performs no auth checking, and thus doesn't set a
+%% requestor in the base state.  This will allow validators to call this endpoint.  When
+%% request signing is in place for this endpoint, this should be changed as appropriate.
+handle_auth_info(chef_wm_named_principal, Req, _State) ->
     case wrq:method(Req) of
         'GET' ->
             authorized;
         _Else ->
             forbidden
     end;
-handle_auth_info(chef_wm_depsolver, Req, _State) ->
+
+handle_auth_info(chef_wm_depsolver, Req, #base_state{requestor = Requestor}) ->
     case wrq:method(Req) of
         'POST' ->
-            authorized;
+            chef_wm_authz:all_but_validators(Requestor);
         _Else ->
             forbidden
     end;

--- a/test/chef_wm_authz_tests.erl
+++ b/test/chef_wm_authz_tests.erl
@@ -32,21 +32,33 @@ make_client(Name, Admin, Validator) ->
   #chef_client{name = Name,
                admin = Admin,
                validator = Validator}.
+make_user(Name, Admin) ->
+  #chef_user{username = Name,
+             admin = Admin}.
 
 -define(ADMIN, make_client(<<"admin">>, true, false)).
 -define(VALIDATOR, make_client(<<"validator">>, false, true)).
 -define(NONADMIN, make_client(<<"normal">>, false, false)).
 
+-define(ADMIN_USER, make_user(<<"admin_user">>, true)).
+-define(NON_ADMIN_USER, make_user(<<"admin_user">>, false)).
+
 allow_admin_test_() ->
-  [
-    {"allow_admin Admin is true",
-    fun() -> ?assertEqual(authorized, chef_wm_authz:allow_admin(?ADMIN)) end},
-    {"allow_admin Validator is false",
-     fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_admin(?VALIDATOR)) end},
-    {"allow_admin non-admin is false",
-     fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_admin(?NONADMIN)) end},
-    {"no match for allow_admin with non-client",
-     fun() -> ?assertError(function_clause, chef_wm_authz:allow_admin(#chef_node{name= <<"foo">>})) end}
+    [
+     {"allow_admin Admin is true",
+      fun() -> ?assertEqual(authorized, chef_wm_authz:allow_admin(?ADMIN)) end},
+     {"allow_admin Validator is false",
+      fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_admin(?VALIDATOR)) end},
+     {"A pathological validator that is also an admin is forbidden anyway",
+      fun() -> ?assertEqual(forbidden,
+                            chef_wm_authz:allow_admin(#chef_client{name = <<"weird_validator">>,
+                                                                   validator = true,
+                                                                   admin = true}))
+      end},
+     {"allow_admin non-admin is false",
+      fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_admin(?NONADMIN)) end},
+     {"no match for allow_admin with non-client",
+      fun() -> ?assertError(function_clause, chef_wm_authz:allow_admin(#chef_node{name= <<"foo">>})) end}
     ].
 
 allow_validator_test_() ->
@@ -88,26 +100,42 @@ is_validator_test_() ->
 allow_admin_or_requesting_node_test_() ->
   NodeName = <<"foo">>,
   NotNode  = <<"not_foo">>,
-  [
-    {"allow_admin_or_requesting_node Admin is true with node name",
-     fun() -> ?assertEqual(authorized, chef_wm_authz:allow_admin_or_requesting_node(make_client(NodeName, true, false),
-                                                                           NodeName)) end},
-    {"allow_admin_or_requesting_node Admin is true with different node name",
-     fun() -> ?assertEqual(authorized, chef_wm_authz:allow_admin_or_requesting_node(make_client(NotNode, true, false),
-                                                                           NodeName)) end},
-    {"allow_admin_or_requesting_node Validator is true with node name",
-     fun() -> ?assertEqual(authorized, chef_wm_authz:allow_admin_or_requesting_node(make_client(NodeName, false, true),
-                                                                           NodeName)) end},
-    {"allow_admin_or_requesting_node Validator is false with different node name",
-     fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_admin_or_requesting_node(make_client(NotNode, false, true),
-                                                                           NodeName)) end},
-    {"allow_admin_or_requesting_node non-admin is true with node name",
-     fun() -> ?assertEqual(authorized, chef_wm_authz:allow_admin_or_requesting_node(make_client(NodeName, false, false),
-                                                                            NodeName)) end},
-    {"allow_admin_or_requesting_node non-admin is false with different node name",
-     fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_admin_or_requesting_node(make_client(NotNode, false, false),
-                                                                            NodeName)) end},
-    {"no match for allow_admin_or_requesting_node with non-client",
-     fun() -> ?assertError(function_clause, chef_wm_authz:allow_admin_or_requesting_node(#chef_node{name= <<"foo">>}, NodeName)) end}
+    [
+     {"allow_admin_or_requesting_node Admin is true with node name",
+      fun() -> ?assertEqual(authorized, chef_wm_authz:allow_admin_or_requesting_node(make_client(NodeName, true, false),
+                                                                                     NodeName)) end},
+     {"allow_admin_or_requesting_node Admin is true with different node name",
+      fun() -> ?assertEqual(authorized, chef_wm_authz:allow_admin_or_requesting_node(make_client(NotNode, true, false),
+                                                                                     NodeName)) end},
+     {"allow_admin_or_requesting_node Validator is false with same node name",
+      fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_admin_or_requesting_node(make_client(NodeName, false, true),
+                                                                                    NodeName)) end},
+     {"allow_admin_or_requesting_node Validator is false with different node name",
+      fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_admin_or_requesting_node(make_client(NotNode, false, true),
+                                                                                    NodeName)) end},
+     {"allow_admin_or_requesting_node non-admin is true with node name",
+      fun() -> ?assertEqual(authorized, chef_wm_authz:allow_admin_or_requesting_node(make_client(NodeName, false, false),
+                                                                                     NodeName)) end},
+     {"allow_admin_or_requesting_node non-admin is false with different node name",
+      fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_admin_or_requesting_node(make_client(NotNode, false, false),
+                                                                                    NodeName)) end},
+     {"no match for allow_admin_or_requesting_node with non-client",
+      fun() -> ?assertError(function_clause, chef_wm_authz:allow_admin_or_requesting_node(#chef_node{name= <<"foo">>},
+                                                                                          NodeName)) end}
+    ].
+
+all_but_validators_test_() ->
+    [
+     {Message,
+      fun() -> ?assertEqual(Expected,
+                            chef_wm_authz:all_but_validators(Requestor))
+      end}
+     || {Message, Requestor, Expected} <- [
+                                           {"Validator is not allowed", ?VALIDATOR, forbidden},
+                                           {"Admin client is allowed", ?ADMIN, authorized},
+                                           {"Non-admin client is allowed", ?NONADMIN, authorized},
+                                           {"Admin user is allowed", ?ADMIN_USER, authorized},
+                                           {"Non-admin user is allowed", ?NON_ADMIN_USER, authorized}
+                                          ]
     ].
 

--- a/test/chef_wm_authz_tests.erl
+++ b/test/chef_wm_authz_tests.erl
@@ -61,18 +61,6 @@ allow_admin_test_() ->
       fun() -> ?assertError(function_clause, chef_wm_authz:allow_admin(#chef_node{name= <<"foo">>})) end}
     ].
 
-allow_validator_test_() ->
-  [
-    {"allow_validator Admin is false",
-     fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_validator(?ADMIN)) end},
-    {"allow_validator Validator is true",
-     fun() -> ?assertEqual(authorized, chef_wm_authz:allow_validator(?VALIDATOR)) end},
-    {"allow_validator non-admin is false",
-     fun() -> ?assertEqual(forbidden, chef_wm_authz:allow_validator(?NONADMIN)) end},
-    {"no match for allow_validator with non-client",
-     fun() -> ?assertError(function_clause, chef_wm_authz:allow_validator(#chef_node{name= <<"foo">>})) end}
-    ].
-
 is_admin_test_() ->
   [
     {"is_admin Admin is true",
@@ -138,4 +126,3 @@ all_but_validators_test_() ->
                                            {"Non-admin user is allowed", ?NON_ADMIN_USER, authorized}
                                           ]
     ].
-


### PR DESCRIPTION
Lockdown validators so they can only be used to create clients.
Further details in commit messages.

@doubt72, there are some tweaks to the principals endpoint I'd
appreciate a 2nd pair of eyes on.
