### PR TITLE
Add server version info

### DIFF
--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -68,6 +68,9 @@
           %% balancer
           reqid_header_name :: string(),
 
+          %% String containing version info for the chef server
+          version_info :: string(),
+
           %% A fun/1 that closes over the request headers and returns
           %% header values as binaries or 'undefined'.
           %% chef_rest_wm:init sets this.

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -80,7 +80,7 @@ init_base_state(ResourceMod, InitParams) ->
     #base_state{reqid_header_name = ?gv(reqid_header_name, InitParams),
                 batch_size = ?gv(batch_size, InitParams),
                 auth_skew = ?gv(auth_skew, InitParams),
-                server_version = ?gv(server_version, InitParams),
+                version_info = ?gv(version, InitParams),
                 resource_mod = ResourceMod}.
 
 %% @doc Determines if service is available.

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -204,7 +204,7 @@ create_500_response(Req, State) ->
     wrq:set_resp_body(Json, Req2).
 
 add_version_header(Req, #base_state{version_info = Version}) ->
-    wrq:set_response_header("X-Ops-API-Version", Version, Req).
+    wrq:set_resp_header("X-Ops-API-Version", Version, Req).
 
 -spec verify_request_signature(#wm_reqdata{}, #base_state{}) ->
                                       {boolean(), #wm_reqdata{}, #base_state{}}.

--- a/src/chef_wm_sup.erl
+++ b/src/chef_wm_sup.erl
@@ -160,7 +160,7 @@ default_resource_init() ->
     Defaults = [{batch_size, get_env(chef_wm, bulk_fetch_batch_size)},
                 {auth_skew, get_env(chef_wm, auth_skew)},
                 {reqid_header_name, get_env(chef_wm, reqid_header_name)},
-                {version_info, get_env(chef_wm, server_version)}],
+                {version, get_env(chef_wm, server_version)}],
     case application:get_env(chef_wm, request_tracing) of
         {ok, true} ->
             [{trace, true}|Defaults];

--- a/src/chef_wm_sup.erl
+++ b/src/chef_wm_sup.erl
@@ -159,7 +159,8 @@ fetch_custom_init_params(Module, Defaults) ->
 default_resource_init() ->
     Defaults = [{batch_size, get_env(chef_wm, bulk_fetch_batch_size)},
                 {auth_skew, get_env(chef_wm, auth_skew)},
-                {reqid_header_name, get_env(chef_wm, reqid_header_name)}],
+                {reqid_header_name, get_env(chef_wm, reqid_header_name)},
+                {server_version, get_env(chef_wm, server_version)}],
     case application:get_env(chef_wm, request_tracing) of
         {ok, true} ->
             [{trace, true}|Defaults];

--- a/src/chef_wm_sup.erl
+++ b/src/chef_wm_sup.erl
@@ -160,7 +160,7 @@ default_resource_init() ->
     Defaults = [{batch_size, get_env(chef_wm, bulk_fetch_batch_size)},
                 {auth_skew, get_env(chef_wm, auth_skew)},
                 {reqid_header_name, get_env(chef_wm, reqid_header_name)},
-                {server_version, get_env(chef_wm, server_version)}],
+                {version_info, get_env(chef_wm, server_version)}],
     case application:get_env(chef_wm, request_tracing) of
         {ok, true} ->
             [{trace, true}|Defaults];


### PR DESCRIPTION
@sf this branch, along with the mm/OC-4709 in omnibus-chef, are the changed needed to get the version info in place. I've left out erchef version info for now. I think we should get this down, then go back and add erchef version info if we want it.
