### PR TITLE
OC-4907 Clients and Users should accept public_key

### DIFF
--- a/src/chef_wm_clients.erl
+++ b/src/chef_wm_clients.erl
@@ -114,18 +114,17 @@ from_json(Req, #base_state{reqid = RequestId,
         {undefined, _} ->
             chef_wm_util:generate_keypair(Name, RequestId);
         {PubKey, _PubKeyVersion} ->
-            {PubKey, null}
+            {PubKey, undefined}
     end,
-    ClientData1 = chef_client:set_public_key(ClientData, PublicKey),
+    ClientData1 = chef_object:set_public_key(ClientData, PublicKey),
     case chef_wm_base:create_from_json(Req, State, chef_client, {authz_id, AuthzId}, ClientData1) of
         {true, Req1, State1} ->
             %% create_from_json by default sets the response to a json body
             %% containing only a uri key. Here we want to add the generated key
             %% pair so we replace the response.
             URI = list_to_binary(chef_wm_util:full_uri(Req1)),
-            EJSON = {[{<<"uri">>, URI},
-                      {<<"private_key">>, PrivateKey},
-                      {<<"public_key">>, PublicKey}]},
+            EJSON = chef_object:set_key_pair({[{<<"uri">>, URI}]},
+                        {public_key, PublicKey}, {private_key, PrivateKey}),
             {true, chef_wm_util:set_json_body(Req1, EJSON), State1};
         Else ->
             Else

--- a/src/chef_wm_named_client.erl
+++ b/src/chef_wm_named_client.erl
@@ -145,7 +145,7 @@ maybe_generate_key_pair(ClientData, RequestId) ->
     case ej:get({<<"private_key">>}, ClientData) of
         true ->
             {PublicKey, PrivateKey} = chef_wm_util:generate_keypair(Name, RequestId),
-            chef_client:set_key_pair(ClientData,
+            chef_object:set_key_pair(ClientData,
                                      {public_key, PublicKey},
                                      {private_key, PrivateKey});
         _ ->

--- a/src/chef_wm_named_user.erl
+++ b/src/chef_wm_named_user.erl
@@ -128,7 +128,7 @@ maybe_generate_key_pair(UserData, RequestId) ->
     case ej:get({<<"private_key">>}, UserData) of
         true ->
             {PublicKey, PrivateKey} = chef_wm_util:generate_keypair(Name, RequestId),
-            chef_user:set_key_pair(UserData,
+            chef_object:set_key_pair(UserData,
                                    {public_key, PublicKey},
                                    {private_key, PrivateKey});
         _ ->

--- a/src/chef_wm_users.erl
+++ b/src/chef_wm_users.erl
@@ -82,18 +82,16 @@ from_json(Req, #base_state{reqid = RequestId,
         {undefined, _} ->
             chef_wm_util:generate_keypair(Name, RequestId);
         {PubKey, _PubKeyVersion} ->
-            {PubKey, null}
+            {PubKey, undefined}
     end,
-    UserWithKey = chef_user:set_public_key(UserData, PublicKey),
+    UserWithKey = chef_object:set_public_key(UserData, PublicKey),
     PasswordData = chef_wm_password:encrypt(ej:get({<<"password">>}, UserWithKey)),
     case create_from_json(Req, State, chef_user, {authz_id, AuthzId},
                           {UserWithKey, PasswordData}) of
         {true, Req1, State1} ->
             Uri = list_to_binary(chef_wm_util:full_uri(Req1)),
-            Ejson = {[{<<"uri">>, Uri},
-                      {<<"private_key">>, PrivateKey},
-                      {<<"public_key">>, PublicKey}
-                     ]},
+            Ejson = chef_object:set_key_pair({[{<<"uri">>, Uri}]},
+                        {public_key, PublicKey}, {private_key, PrivateKey}),
             {true, chef_wm_util:set_json_body(Req1, Ejson), State1};
         Else ->
             Else


### PR DESCRIPTION
- create users should accept public_key
- create clients should accept public_key

No changes to chef_wm were required to get update users and update clients to accept public_key

See:
- https://github.com/opscode/chef_wm/pull/39
- https://github.com/opscode/chef_objects/pull/26
- https://github.com/opscode/chef-pedant/pull/8
