### PR TITLE
OC-4709: Add server api version header

### DIFF
--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -68,6 +68,9 @@
           %% balancer
           reqid_header_name :: string(),
 
+          %% String containing version info for the chef server
+          version_info :: string(),
+
           %% A fun/1 that closes over the request headers and returns
           %% header values as binaries or 'undefined'.
           %% chef_rest_wm:init sets this.

--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -68,8 +68,15 @@
           %% balancer
           reqid_header_name :: string(),
 
-          %% String containing version info for the chef server
-          version_info :: string(),
+          %% String containing API version info for the chef server
+          api_version :: string(),
+
+          %% OTP information for the Erchef server in {ReleaseName, OtpVersion} form.
+          otp_info :: {string(), string()},
+
+          %% Indicates what variant of Chef Server this is (e.g. "osc" => Open Source Chef,
+          %% "opc" = Opscode Private Chef, etc).
+          server_flavor :: string(),
 
           %% A fun/1 that closes over the request headers and returns
           %% header values as binaries or 'undefined'.

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -80,7 +80,7 @@ init_base_state(ResourceMod, InitParams) ->
     #base_state{reqid_header_name = ?gv(reqid_header_name, InitParams),
                 batch_size = ?gv(batch_size, InitParams),
                 auth_skew = ?gv(auth_skew, InitParams),
-                server_version = ?gv(server_version, InitParams),
+                version_info = ?gv(version, InitParams),
                 resource_mod = ResourceMod}.
 
 %% @doc Determines if service is available.

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -204,7 +204,7 @@ create_500_response(Req, State) ->
     wrq:set_resp_body(Json, Req2).
 
 add_version_header(Req, #base_state{version_info = Version}) ->
-    wrq:set_response_header("X-Ops-API-Version", Version, Req).
+    wrq:set_resp_header("X-Ops-API-Version", Version, Req).
 
 -spec verify_request_signature(#wm_reqdata{}, #base_state{}) ->
                                       {boolean(), #wm_reqdata{}, #base_state{}}.

--- a/src/chef_wm_sup.erl
+++ b/src/chef_wm_sup.erl
@@ -160,7 +160,7 @@ default_resource_init() ->
     Defaults = [{batch_size, get_env(chef_wm, bulk_fetch_batch_size)},
                 {auth_skew, get_env(chef_wm, auth_skew)},
                 {reqid_header_name, get_env(chef_wm, reqid_header_name)},
-                {version_info, get_env(chef_wm, server_version)}],
+                {version, get_env(chef_wm, server_version)}],
     case application:get_env(chef_wm, request_tracing) of
         {ok, true} ->
             [{trace, true}|Defaults];

--- a/src/chef_wm_sup.erl
+++ b/src/chef_wm_sup.erl
@@ -157,10 +157,19 @@ fetch_custom_init_params(Module, Defaults) ->
 
 %% @doc Return a proplist of init parameters that should be passed to all resource modules.
 default_resource_init() ->
+    %% We will only have one release, until such time as we start doing live upgrades.  When
+    %% and if that time comes, this will probably fail.
+    [{ServerName, ServerVersion, _, _}] = release_handler:which_releases(permanent),
+
     Defaults = [{batch_size, get_env(chef_wm, bulk_fetch_batch_size)},
                 {auth_skew, get_env(chef_wm, auth_skew)},
                 {reqid_header_name, get_env(chef_wm, reqid_header_name)},
-                {version, get_env(chef_wm, server_version)}],
+
+                %% These will be used to generate the X-Ops-API-Info header
+                {otp_info, {ServerName, ServerVersion}},
+                {server_flavor, get_env(chef_wm, server_flavor)},
+                {api_version, get_env(chef_wm, api_version)}
+               ],
     case application:get_env(chef_wm, request_tracing) of
         {ok, true} ->
             [{trace, true}|Defaults];

--- a/src/chef_wm_sup.erl
+++ b/src/chef_wm_sup.erl
@@ -159,7 +159,8 @@ fetch_custom_init_params(Module, Defaults) ->
 default_resource_init() ->
     Defaults = [{batch_size, get_env(chef_wm, bulk_fetch_batch_size)},
                 {auth_skew, get_env(chef_wm, auth_skew)},
-                {reqid_header_name, get_env(chef_wm, reqid_header_name)}],
+                {reqid_header_name, get_env(chef_wm, reqid_header_name)},
+                {server_version, get_env(chef_wm, server_version)}],
     case application:get_env(chef_wm, request_tracing) of
         {ok, true} ->
             [{trace, true}|Defaults];

--- a/src/chef_wm_sup.erl
+++ b/src/chef_wm_sup.erl
@@ -160,7 +160,7 @@ default_resource_init() ->
     Defaults = [{batch_size, get_env(chef_wm, bulk_fetch_batch_size)},
                 {auth_skew, get_env(chef_wm, auth_skew)},
                 {reqid_header_name, get_env(chef_wm, reqid_header_name)},
-                {server_version, get_env(chef_wm, server_version)}],
+                {version_info, get_env(chef_wm, server_version)}],
     case application:get_env(chef_wm, request_tracing) of
         {ok, true} ->
             [{trace, true}|Defaults];


### PR DESCRIPTION
This adds an X-Ops-API-Info header to Erchef server responses.

It contains the "flavor" of server (i.e. "osc" or "opc"), the logical
server version (e.g. "11.0.0" for upcoming Chef 11), and the OTP
version of the Erchef release (mainly useful for debugging).

An example:

```
vagrant@open-source-chef:/srv/piab/mounts/erchef$ curl -I 127.0.0.1:8000/nodes
HTTP/1.1 405 Method Not Allowed
X-Ops-API-Info: flavor=osc;version=11.0.0;erchef=1.0.9
Server: MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)
Date: Wed, 21 Nov 2012 02:37:36 GMT
Content-Length: 0
Allow: GET, POST
```

(quick-and-dirty test with an unauthenticated request, but you get the picture.)

This has been confirmed on Omnibus builds of both Erchef servers.
