### PR TITLE
OC-5211 Validate Public Key for Clients and Users

### DIFF
--- a/src/chef_wm_malformed.erl
+++ b/src/chef_wm_malformed.erl
@@ -168,7 +168,8 @@ malformed_request_message(#ej_invalid{type = object_value,
                                       found = Val}, _Req, _State) ->
     error_envelope([<<"Invalid value '">>, Val, <<"' for ">>, Object]);
 
-
+malformed_request_message(#ej_invalid{type = fun_match, msg = Message}, _Req, _State) ->
+    error_envelope([Message]);
 malformed_request_message(Reason, Req, #base_state{resource_mod=Mod}=State) ->
     Mod:malformed_request_message(Reason, Req, State).
 

--- a/src/chef_wm_named_user.erl
+++ b/src/chef_wm_named_user.erl
@@ -171,8 +171,6 @@ malformed_request_message(#ej_invalid{type = object_value, key = Object, found =
                           _Req, _State) ->
     error_message([<<"Invalid value '">>, io_lib:format("~p", [Val]),
                    <<"' for ">>, Object]);
-malformed_request_message(#ej_invalid{type = fun_match, msg = Message}, _Req, _State) ->
-    error_message([Message]);
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
 


### PR DESCRIPTION
- Added a API-wide malformed_request_message clause for fun_match validators
- This effects sandbox validation, https://github.com/opscode/chef-pedant/pull/13 has been updated to match

Related:
- https://github.com/opscode/chef_objects/pull/28
- https://github.com/opscode/chef-pedant/pull/13
