### PR TITLE
CHEF-3697 Admin and Validation Clients

### DIFF
--- a/src/chef_wm_authz.erl
+++ b/src/chef_wm_authz.erl
@@ -30,6 +30,7 @@
          allow_admin_or_requesting_client/2,
          allow_admin_or_requesting_node/2,
          is_admin/1,
+         is_requesting_client/2,
          is_requesting_node/2,
          is_validator/1]).
 
@@ -67,11 +68,12 @@ allow_admin_or_requesting_node(#chef_user{} = User, _Name)            -> allow_a
 %%
 %% Validators can only create clients, get info on itself, and update itself. It cannot do
 %% anything else, including operating on node resources.
+%%
+%% Forbids non-admin users with the same name as the client
 -spec allow_admin_or_requesting_client(#chef_client{} | #chef_user{}, binary()) -> authorized | forbidden.
 allow_admin_or_requesting_client(#chef_client{name = Name}, Name)       -> authorized;
 allow_admin_or_requesting_client(#chef_client{validator = true}, _Name) -> forbidden;
 allow_admin_or_requesting_client(#chef_client{} = Client, _Name)        -> allow_admin(Client);
-allow_admin_or_requesting_client(#chef_user{username = Name}, Name)     -> authorized;
 allow_admin_or_requesting_client(#chef_user{} = User, _Name)            -> allow_admin(User).
 
 is_admin(#chef_client{admin = true}) -> true;
@@ -86,6 +88,13 @@ is_requesting_node(#chef_client{}, _Name)             -> false;
 is_requesting_node(#chef_user{username = Name}, Name) -> true;
 is_requesting_node(#chef_user{}, _Name)               -> false.
 
+%% Specifically does not allow users with the same name as the client
+-spec is_requesting_client(#chef_client{} | #chef_user{}, binary()) -> true | false.
+is_requesting_client(#chef_client{name = Name}, Name)   -> true;
+is_requesting_client(_, _)                              -> false.
+
 is_validator(#chef_client{validator = true}) -> true;
 is_validator(#chef_client{})                 -> false;
 is_validator(#chef_user{})                   -> false.
+
+

--- a/src/chef_wm_authz.erl
+++ b/src/chef_wm_authz.erl
@@ -27,6 +27,7 @@
 -export([
          all_but_validators/1,
          allow_admin/1,
+         allow_admin_or_requesting_client/2,
          allow_admin_or_requesting_node/2,
          is_admin/1,
          is_requesting_node/2,
@@ -52,14 +53,26 @@ allow_admin(#chef_user{})                   -> forbidden.
 %% @doc Admins can do what they wish, but other requestors can only proceed if they are
 %% operating on themselves.
 %%
-%% Validators can only create new clients, and cannot even operate on themselves; if you
-%% need to modify a validator for some reason, do it as a proper admin
+%% Validators can only create clients, get info on itself, and update itself. It cannot do
+%% anything else, including operating on node resources.
 -spec allow_admin_or_requesting_node(#chef_client{} | #chef_user{}, binary()) -> authorized | forbidden.
 allow_admin_or_requesting_node(#chef_client{validator = true}, _Name) -> forbidden;
 allow_admin_or_requesting_node(#chef_client{name = Name}, Name)       -> authorized;
 allow_admin_or_requesting_node(#chef_client{} = Client, _Name)        -> allow_admin(Client);
 allow_admin_or_requesting_node(#chef_user{username = Name}, Name)     -> authorized;
 allow_admin_or_requesting_node(#chef_user{} = User, _Name)            -> allow_admin(User).
+
+%% @doc Admins can do what they wish, but other requestors can only proceed if they are
+%% operating on themselves.
+%%
+%% Validators can only create clients, get info on itself, and update itself. It cannot do
+%% anything else, including operating on node resources.
+-spec allow_admin_or_requesting_client(#chef_client{} | #chef_user{}, binary()) -> authorized | forbidden.
+allow_admin_or_requesting_client(#chef_client{name = Name}, Name)       -> authorized;
+allow_admin_or_requesting_client(#chef_client{validator = true}, _Name) -> forbidden;
+allow_admin_or_requesting_client(#chef_client{} = Client, _Name)        -> allow_admin(Client);
+allow_admin_or_requesting_client(#chef_user{username = Name}, Name)     -> authorized;
+allow_admin_or_requesting_client(#chef_user{} = User, _Name)            -> allow_admin(User).
 
 is_admin(#chef_client{admin = true}) -> true;
 is_admin(#chef_client{})             -> false;

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -662,11 +662,39 @@ handle_auth_info(chef_wm_clients, Req,
     end;
 handle_auth_info(chef_wm_named_client, Req, #base_state{requestor = Requestor,
                                                         resource_state =
-                                                            #client_state{chef_client = Client}}) ->
+                                                            #client_state{client_data = ClientData}}) ->
     ClientName = chef_wm_util:object_name(client, Req),
     case wrq:method(Req) of
         'PUT' ->
-            chef_wm_authz:allow_admin(Requestor);
+            RequestorIsModifyingSelf = chef_wm_authz:is_requesting_client(Requestor, ClientName),
+            RequestorIsNotAdmin = chef_wm_authz:is_admin(Requestor) =:= false,
+            RequestorIsNotValidator = chef_wm_authz:is_validator(Requestor) =:= false,
+
+            UpdateToAdmin = ej:get({<<"admin">>}, ClientData),
+            UpdateToValidator = ej:get({<<"validator">>}, ClientData),
+
+            %% Is a non-admin trying to upgrade to an admin?
+            EscalateAdminAttempt = RequestorIsNotAdmin andalso UpdateToAdmin,
+
+            %% Is a non-admin, non-validator trying to upgrade to validator?
+            EscalateValidatorAttempt = RequestorIsNotAdmin andalso RequestorIsNotValidator andalso UpdateToValidator,
+
+            EscalateAttempt = EscalateAdminAttempt orelse EscalateValidatorAttempt,
+
+            case {RequestorIsModifyingSelf, EscalateAttempt} of
+                {true, true} ->
+                    %% Non-admin clients cannot give admin privs to themselves.
+                    %% Non-admin clients cannot give validator privs to themselves
+                    forbidden;
+                {_, _} ->
+                    %% Admins can change whatever else they like for other users or
+                    %% themselves, and non-admins can change whatever for themselves
+                    %% as long as it is not escalating privs.
+
+                    %% Unlike users, we do not check for last client admin. As long as there is one admin user left,
+                    %% it can create another admin client
+                    chef_wm_authz:allow_admin_or_requesting_client(Requestor, ClientName)
+            end;
         Method when Method =:= 'GET';
                     Method =:= 'DELETE' ->
             chef_wm_authz:allow_admin_or_requesting_client(Requestor, ClientName);

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -669,7 +669,7 @@ handle_auth_info(chef_wm_named_client, Req, #base_state{requestor = Requestor,
             chef_wm_authz:allow_admin(Requestor);
         Method when Method =:= 'GET';
                     Method =:= 'DELETE' ->
-            chef_wm_authz:allow_admin_or_requesting_node(Requestor, ClientName);
+            chef_wm_authz:allow_admin_or_requesting_client(Requestor, ClientName);
         _Else ->
             forbidden
     end;


### PR DESCRIPTION
Clients cannot be both admin and validator.

See:
- https://github.com/opscode/chef-pedant/pull/24
- https://github.com/opscode/chef_objects/pull/30
