### PR TITLE
Convert to new stats_hero supporting custom module config

### DIFF
--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -129,7 +129,10 @@
 
           %% Turn this on if superuser is allowed to bypass security checks for
           %% this endpoint.
-          superuser_bypasses_checks = false :: true | false
+          superuser_bypasses_checks = false :: true | false,
+
+          %% A proplist of config for metric reporting and stats_hero integration.
+          metrics_config :: [{atom(), term()}]
          }).
 
 -record(client_state, {

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -87,6 +87,7 @@ init_base_state(ResourceMod, InitParams) ->
                 server_flavor = ?gv(server_flavor, InitParams),
                 api_version = ?gv(api_version, InitParams),
 
+                metrics_config = ?gv(metrics_config, InitParams),
                 resource_mod = ResourceMod}.
 
 %% @doc Determines if service is available.

--- a/src/chef_wm_sup.erl
+++ b/src/chef_wm_sup.erl
@@ -23,6 +23,8 @@
 
 -behaviour(supervisor).
 
+-include("chef_wm.hrl").
+
 %% External exports
 -export([start_link/0, upgrade/0]).
 
@@ -168,7 +170,19 @@ default_resource_init() ->
                 %% These will be used to generate the X-Ops-API-Info header
                 {otp_info, {ServerName, ServerVersion}},
                 {server_flavor, get_env(chef_wm, server_flavor)},
-                {api_version, get_env(chef_wm, api_version)}
+                {api_version, get_env(chef_wm, api_version)},
+
+                %% metrics and stats_hero config. We organize these into a proplist which
+                %% will end up in the base_state record rather than having a key for each of
+                %% these in base state.
+                {metrics_config,
+                 [{root_metric_key, get_env(chef_wm, root_metric_key)},
+                  %% the following two are hard-coded calls to ?BASE_RESOURCE. These could
+                  %% be factored out into app config if we wanted ultimate flexibility. At
+                  %% that point, we might want a label and upstream function to form a
+                  %% behavior defined in stats_hero.
+                  {stats_hero_upstreams, ?BASE_RESOURCE:stats_hero_upstreams()},
+                  {stats_hero_label_fun, {?BASE_RESOURCE, stats_hero_label}}]}
                ],
     case application:get_env(chef_wm, request_tracing) of
         {ok, true} ->

--- a/test/chef_wm_base_tests.erl
+++ b/test/chef_wm_base_tests.erl
@@ -1,0 +1,35 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(chef_wm_base_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+stats_hero_label_test_() ->
+    GoodTests = [
+                 ?_assertEqual(Expect, chef_wm_base:stats_hero_label(In))
+                 || {In, Expect} <- [
+                                     %% {Input, Expected}
+                                     {{chef_sql, fetch_client}, <<"rdbms.chef_sql.fetch_client">>},
+                                     {{chef_solr, some_fun}, <<"solr.chef_solr.some_fun">>}
+                                    ] ],
+    BadTests = [
+                ?_assertError({bad_prefix, {bad, juju}},
+                              chef_wm_base:stats_hero_label({bad, juju})) ],
+    GoodTests ++ BadTests.


### PR DESCRIPTION
The sf/modular-config branch of stats_hero removes hard-coding of
module names used for metric aggregation along with a few other minor
improvements.

This PR includes the changes required to use the new stats_hero.

A few of the commits will be updated prior to merge since we will
merge stats_hero to master and same for chef_wm.

I built a local deb using omnibus-chef, verified a full pedant
run, and drove some traffic at it to verify that metrics appear in
graphite.
