### PR TITLE
stats_hero instrumentation of Bookshelf / S3 upstream

### DIFF
--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -900,17 +900,11 @@ set_forbidden_msg(Req, State) ->
 %% encode the mapping of module to upstream label.
 -spec stats_hero_label({Mod::metric_module(), Fun::atom()}) -> <<_:16,_:_*8>>.
 stats_hero_label({chef_sql, Fun}) ->
-    stats_hero_label0(rdbms, {chef_sql, Fun});
+    chef_metrics:label(rdbms, {chef_sql, Fun});
 stats_hero_label({chef_solr, Fun}) ->
-    stats_hero_label0(solr, {chef_solr, Fun});
+    chef_metrics:label(solr, {chef_solr, Fun});
 stats_hero_label({BadPrefix, Fun}) ->
     erlang:error({bad_prefix, {BadPrefix, Fun}}).
-
-stats_hero_label0(Prefix, {Mod, Fun}) ->
-    PrefixBin = erlang:atom_to_binary(Prefix, utf8),
-    ModBin = erlang:atom_to_binary(Mod, utf8),
-    FunBin = erlang:atom_to_binary(Fun, utf8),
-    <<PrefixBin/binary, ".", ModBin/binary, ".", FunBin/binary>>.
 
 %% @doc The prefixes that stats_hero should use for aggregating timing data over each
 %% request.

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -893,7 +893,7 @@ set_forbidden_msg(Req, State) ->
 
 %% These are modules that we instrument with stats_hero and aggregate into common prefix via
 %% stats_hero_label.
--type metric_module() :: chef_sql | chef_solr.
+-type metric_module() :: chef_s3 | chef_sql | chef_solr.
 
 %% @doc Given a `{Mod, Fun}' tuple, generate a stats hero metric with a prefix appropriate
 %% for stats_hero aggregation. An error is thrown if `Mod' is unknown. This is where we
@@ -903,10 +903,12 @@ stats_hero_label({chef_sql, Fun}) ->
     chef_metrics:label(rdbms, {chef_sql, Fun});
 stats_hero_label({chef_solr, Fun}) ->
     chef_metrics:label(solr, {chef_solr, Fun});
+stats_hero_label({chef_s3, Fun}) ->
+    chef_metrics:label(bookshelf, {chef_s3, Fun});
 stats_hero_label({BadPrefix, Fun}) ->
     erlang:error({bad_prefix, {BadPrefix, Fun}}).
 
 %% @doc The prefixes that stats_hero should use for aggregating timing data over each
 %% request.
 stats_hero_upstreams() ->
-    [<<"rdbms">>, <<"solr">>].
+    [<<"bookshelf">>, <<"rdbms">>, <<"solr">>].

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -904,11 +904,11 @@ stats_hero_label({chef_sql, Fun}) ->
 stats_hero_label({chef_solr, Fun}) ->
     chef_metrics:label(solr, {chef_solr, Fun});
 stats_hero_label({chef_s3, Fun}) ->
-    chef_metrics:label(bookshelf, {chef_s3, Fun});
+    chef_metrics:label(s3, {chef_s3, Fun});
 stats_hero_label({BadPrefix, Fun}) ->
     erlang:error({bad_prefix, {BadPrefix, Fun}}).
 
 %% @doc The prefixes that stats_hero should use for aggregating timing data over each
 %% request.
 stats_hero_upstreams() ->
-    [<<"bookshelf">>, <<"rdbms">>, <<"solr">>].
+    [<<"rdbms">>, <<"s3">>, <<"solr">>].

--- a/test/chef_wm_base_tests.erl
+++ b/test/chef_wm_base_tests.erl
@@ -32,7 +32,7 @@ stats_hero_label_test_() ->
                                      %% {Input, Expected}
                                      {{chef_sql, fetch_client}, <<"rdbms.chef_sql.fetch_client">>},
                                      {{chef_solr, some_fun}, <<"solr.chef_solr.some_fun">>},
-                                     {{chef_s3, delete_checksums}, <<"bookshelf.s3_amazonaws_com.test_bucket.chef_s3.delete_checksums">>}
+                                     {{chef_s3, delete_checksums}, <<"s3.s3_amazonaws_com.test_bucket.chef_s3.delete_checksums">>}
                                     ] ],
 
 

--- a/test/chef_wm_base_tests.erl
+++ b/test/chef_wm_base_tests.erl
@@ -22,13 +22,20 @@
 -include_lib("eunit/include/eunit.hrl").
 
 stats_hero_label_test_() ->
+
+    application:set_env(chef_objects, s3_url, "http://s3.amazonaws.com"),
+    application:set_env(chef_objects, s3_platform_bucket_name, "test.bucket"),
+
     GoodTests = [
                  ?_assertEqual(Expect, chef_wm_base:stats_hero_label(In))
                  || {In, Expect} <- [
                                      %% {Input, Expected}
                                      {{chef_sql, fetch_client}, <<"rdbms.chef_sql.fetch_client">>},
-                                     {{chef_solr, some_fun}, <<"solr.chef_solr.some_fun">>}
+                                     {{chef_solr, some_fun}, <<"solr.chef_solr.some_fun">>},
+                                     {{chef_s3, delete_checksums}, <<"bookshelf.s3_amazonaws_com.test_bucket.chef_s3.delete_checksums">>}
                                     ] ],
+
+
     BadTests = [
                 ?_assertError({bad_prefix, {bad, juju}},
                               chef_wm_base:stats_hero_label({bad, juju})) ],


### PR DESCRIPTION
This allows Erchef to log metrics on Bookshelf / S3 operations
(currently `chef_s3:check_checksums/2` and
`chef_s3:delete_checksums/2`).

Metric labels differ from existing labels in that they incorporate
both the storage hostname and storage bucket, in addition to the
standard upstream, module, and function names.

To facilitate this, label generation was extracted into a new module,
`chef_metrics` in the `chef_objects` application.
