### PR TITLE
OC-5178: Update erlware_commons

### DIFF
--- a/src/chef_wm_depsolver.erl
+++ b/src/chef_wm_depsolver.erl
@@ -270,7 +270,9 @@ assemble_response(Req, State, CookbookVersions) ->
             CBMapJson = chef_json:encode(JsonList),
             {true, wrq:append_to_response_body(CBMapJson, Req), State};
         {error, Msg} ->
-            forbid(Req, State, Msg, {read, forbidden})
+            forbid(Req, State, Msg, {read, forbidden});
+        {timeout, Msg} ->
+            server_error(Req, State, Msg, {timeout, cookbook_authz})
     end.
 
 %%------------------------------------------------------------------------------

--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -128,8 +128,9 @@ not_found_message(user, Name) ->
 
 error_message_envelope(Message) when is_binary(Message) orelse
                                      is_tuple(Message) ->
-    %% Tuple guard added to accommodate depsolver messages.  This is part of an ongoing
-    %% refactor, and may not ultimately be necessary.
+    %% Tuple guard is really intended for grabbing EJson-encoded json objects, but we don't
+    %% have guards for that.  It was added to accommodate depsolver messages.  This is part
+    %% of an ongoing refactor, and may not ultimately be necessary.
     {[{<<"error">>, [Message]}]}.
 
 %% @doc Converts the given Ejson-encoded data to a JSON string and


### PR DESCRIPTION
This pulls in changes to `chef_objects` to fully update / replace
`erlware_commons` usage, as well as the necessary new configuration
parameters to make it work.
