### PR TITLE
Add search result caching

### DIFF
--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -41,6 +41,10 @@
 -define(BASE_ROUTES, chef_wm_routes).
 -endif.
 
+-ifndef(SEARCH_CACHE).
+-define(SEARCH_CACHE, chef_wm_search_cache).
+-endif.
+
 -type permission() :: create | delete | read | update.
 
 -type container_name() :: cookbook |

--- a/src/chef_wm_search_cache.erl
+++ b/src/chef_wm_search_cache.erl
@@ -1,0 +1,24 @@
+%% @doc A no-op search cache module. This module implements the search
+%% cache interface, but never caches anything.
+-module(chef_wm_search_cache).
+
+-export([
+         get/2,
+         make_key/6,
+         put/3
+        ]).
+
+get(_ReqId, _Key) ->
+    %% this is an ugly way of making dialyzer happy with this
+    case random:uniform(1) of
+        1 ->
+            not_found;
+        _ ->
+            {0, <<"dummy cache value">>}
+    end.
+
+put(_ReqId, _Key, _Value) ->
+    ok.
+
+make_key(_OrgName, _BatchSize, _Start, _Ids, _RawPath, _Paths) ->
+    dummy_key.


### PR DESCRIPTION
These PRs add the ability to cache search results to reduce load on
backend dbs.

For chef_wm, the cache defaults to a no-op cache.
