### PR TITLE
Upgrade to webmachine 1.10.1 (and be compatible w/ Erlang R16)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,12 @@
 
 {deps,
  [
+  %% Note that webmachine needs to come before chef_index to ensure we
+  %% get mochiweb as specified by webmachine and not the one from
+  %% gen_bunny.
+  {webmachine, ".*",
+   {git, "git://github.com/basho/webmachine", {tag, "1.10.1"}}},
+
   {chef_authn, ".*",
    {git, "git://github.com/opscode/chef_authn.git", {branch, "master"}}},
 
@@ -21,9 +27,6 @@
 
   {bcrypt, ".*",
    {git, "git://github.com/opscode/erlang-bcrypt.git", {tag, "0.5.0.2"}}},
-
-  {webmachine, ".*",
-   {git, "git://github.com/basho/webmachine", {tag, "1.9.0-mochifix"}}},
 
   {fast_log, ".*",
    {git, "git://github.com/opscode/fast-log-erlang.git", {branch, "master"}}},

--- a/src/chef_wm_clients.erl
+++ b/src/chef_wm_clients.erl
@@ -122,7 +122,7 @@ from_json(Req, #base_state{reqid = RequestId,
             %% create_from_json by default sets the response to a json body
             %% containing only a uri key. Here we want to add the generated key
             %% pair so we replace the response.
-            URI = list_to_binary(chef_wm_util:full_uri(Req1)),
+            URI = ?BASE_ROUTES:route(client, Req1, [{name, Name}]),
             EJSON = chef_object:set_key_pair({[{<<"uri">>, URI}]},
                         {public_key, PublicKey}, {private_key, PrivateKey}),
             {true, chef_wm_util:set_json_body(Req1, EJSON), State1};

--- a/src/chef_wm_users.erl
+++ b/src/chef_wm_users.erl
@@ -89,7 +89,7 @@ from_json(Req, #base_state{reqid = RequestId,
     case create_from_json(Req, State, chef_user, {authz_id, AuthzId},
                           {UserWithKey, PasswordData}) of
         {true, Req1, State1} ->
-            Uri = list_to_binary(chef_wm_util:full_uri(Req1)),
+            Uri = ?BASE_ROUTES:route(user, Req1, [{name, Name}]),
             Ejson = chef_object:set_key_pair({[{<<"uri">>, Uri}]},
                         {public_key, PublicKey}, {private_key, PrivateKey}),
             {true, chef_wm_util:set_json_body(Req1, Ejson), State1};

--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -26,7 +26,6 @@
          environment_not_found_message/1,
          error_message_envelope/1,
          extract_from_path/2,
-         full_uri/1,
          get_header_fun/2,
          malformed_request_message/3,
          admin_field_is_false/1,
@@ -36,7 +35,6 @@
          num_versions/2,
          object_name/2,
          set_json_body/2,
-         set_uri_of_created_resource/1,
          set_uri_of_created_resource/2,
          with_error_body/2,
          generate_keypair/2]).
@@ -55,12 +53,9 @@ base_mods() ->
 %% @doc Returns the base URI for the server as called by the client as a string.
 base_uri(Req) ->
     Scheme = scheme(Req),
-    Host = string:join(lists:reverse(wrq:host_tokens(Req)), "."),
+    Host = string:join(wrq:host_tokens(Req), "."),
     PortString = port_string(wrq:port(Req)),
     Scheme ++ "://" ++ Host ++ PortString.
-
-full_uri(Req) ->
-    base_uri(Req) ++ wrq:disp_path(Req).
 
 get_header_fun(Req, State = #base_state{header_fun = HFun})
   when HFun =:= undefined ->
@@ -158,8 +153,6 @@ with_error_body(Req, ErrorData) ->
 %%     {"uri":"http://foo.com/newresource"}
 %% '''
 %% Returns the updated request.
-set_uri_of_created_resource(Req) ->
-    set_uri_of_created_resource(chef_wm_util:full_uri(Req), Req).
 set_uri_of_created_resource(Uri, Req) when is_list(Uri) ->
     set_uri_of_created_resource(list_to_binary(Uri), Req);
 set_uri_of_created_resource(Uri, Req0) when is_binary(Uri) ->


### PR DESCRIPTION
This multi-repo PR upgrades the webmachine (and bundled mochiweb)
version to 1.10.1. Among other fixes, the new versions of webmachine
and mochiweb no longer use parameterized modules, a feature which has
been removed from Erlang >= R16.

While, I've done some testing with R16B and things look good (and
despite the branch name) these patches upgrade wm and include a few
other compat fixes for R16, but erlang is left at R15B03 and things
work fine there too.

Note that the PR in opscode-omnibus is for testing only and will not
be merged.
