### PR TITLE
Integrate new depsolver with semver support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,13 +17,13 @@
    {git, "git://github.com/opscode/chef_certgen.git", {branch, "master"}}},
 
   {chef_db, ".*",
-   {git, "git://github.com/opscode/chef_db.git", {branch, "master"}}},
+   {git, "git://github.com/opscode/chef_db.git", {branch, "sf/eric-semver"}}},
 
   {chef_index, ".*",
-   {git, "git://github.com/opscode/chef_index.git", {branch, "master"}}},
+   {git, "git://github.com/opscode/chef_index.git", {branch, "sf/eric-semver"}}},
 
   {chef_objects, ".*",
-   {git, "git://github.com/opscode/chef_objects.git", {branch, "master"}}},
+   {git, "git://github.com/opscode/chef_objects.git", {branch, "sf/eric-semver"}}},
 
   {bcrypt, ".*",
    {git, "git://github.com/opscode/erlang-bcrypt.git", {tag, "0.5.0.3"}}},


### PR DESCRIPTION
This set of PRs integrates an update to depsolver that includes
support for semver versions at the depsolver layer. It does NOT add
support at the chef level, but everything is working with the API
change in depsolver.
