### PR TITLE
Implement Hosted Chef / Private Chef Clients Endpoint in Erlang 

### DIFF
--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -48,7 +48,7 @@
 -export([assemble_principal_ejson/3,
          check_cookbook_authz/3,
          delete_object/3,
-         maybe_process_client/2,
+         object_creation_hook/2,
          stats_hero_label/1,
          stats_hero_upstreams/0]).
 
@@ -296,9 +296,8 @@ create_from_json(#wm_reqdata{} = Req,
     Name = chef_object:name(ObjectRec),
     TypeName = chef_object:type_name(ObjectRec),
 
-
-    ObjectRec = ?BASE_RESOURCE:maybe_process_client(ObjectRec, State),
-
+    %% Perform any additional platform-specific work on the object
+    ObjectRec = ?BASE_RESOURCE:object_creation_hook(ObjectRec, State),
 
     %% We send the object data to solr for indexing *first*. If it fails, we'll error out on
     %% a 500 and client can retry. If we succeed and the db call fails or conflicts, we can
@@ -329,7 +328,7 @@ create_from_json(#wm_reqdata{} = Req,
     end.
 
 %% Open Source Chef Server doesn't need to do anything else.
-maybe_process_client(Object, _State) -> Object.
+object_creation_hook(Object, _State) -> Object.
 
 -spec update_from_json(#wm_reqdata{},
                        #base_state{},

--- a/src/chef_wm_named_client.erl
+++ b/src/chef_wm_named_client.erl
@@ -111,7 +111,7 @@ auth_info(Req, #base_state{resource_state =
                                                  Client} = ClientState} = State) ->
     ClientState1 = ClientState#client_state{chef_client = Client},
     State1 = State#base_state{resource_state = ClientState1},
-    {{object, AuthzId}, Req, State1}.
+    {{actor, AuthzId}, Req, State1}.
 
 from_json(Req, #base_state{reqid = RequestId,
                            resource_state =


### PR DESCRIPTION
On the Erchef side, we do some post-processing of clients after they
are created to ensure they have the correct permissions, group
memberships, etc.  This doesn't happen in Open Source Chef
(obviously), but due to the way code is both shared and altered at
compile time, we need to introduce a "hook" for this functionality
into `chef_wm`. 
