### PR TITLE
Return 503 for missing checksum in sandbox commit for retry

### DIFF
--- a/src/chef_wm_named_sandbox.erl
+++ b/src/chef_wm_named_sandbox.erl
@@ -108,7 +108,7 @@ from_json(Req, #base_state{reqid = ReqId,
                                     <<": the following checksums have not been uploaded: ">>,
                                     SumList]),
             EMsg = chef_wm_util:error_message_envelope(Msg),
-            {{halt, 400}, chef_wm_util:set_json_body(Req, EMsg), State}
+            {{halt, 503}, chef_wm_util:set_json_body(Req, EMsg), State}
     end.
 
 %% Private utility functions


### PR DESCRIPTION
When cookbook content is stored in an eventually consistent store
such as S3, a missing checksum on sandbox commit should be
retried to allow the store to update. This matches the behavior
of the OHC API.
