### PR TITLE
Add stats_hero timing metrics to depsolver calls

### DIFF
--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -919,10 +919,12 @@ stats_hero_label({chef_solr, Fun}) ->
     chef_metrics:label(solr, {chef_solr, Fun});
 stats_hero_label({chef_s3, Fun}) ->
     chef_metrics:label(s3, {chef_s3, Fun});
+stats_hero_label({chef_depsolver, Fun}) ->
+    chef_metrics:label(depsolver, {chef_depsolver, Fun});
 stats_hero_label({BadPrefix, Fun}) ->
     erlang:error({bad_prefix, {BadPrefix, Fun}}).
 
 %% @doc The prefixes that stats_hero should use for aggregating timing data over each
 %% request.
 stats_hero_upstreams() ->
-    [<<"rdbms">>, <<"s3">>, <<"solr">>].
+    [<<"depsolver">>, <<"rdbms">>, <<"s3">>, <<"solr">>].

--- a/src/chef_wm_depsolver.erl
+++ b/src/chef_wm_depsolver.erl
@@ -104,7 +104,8 @@ forbidden_for_environment(#chef_environment{authz_id = EnvAuthzId} = Env, Req,
 post_is_create(Req, State) ->
     {false, Req, State}.
 
-process_post(Req, #base_state{chef_db_context = DbContext,
+process_post(Req, #base_state{reqid = ReqId,
+                              chef_db_context = DbContext,
                               organization_name = OrgName,
                               resource_state = #depsolver_state{run_list_cookbooks = Cookbooks,
                                                                 environment_name = EnvName,
@@ -118,8 +119,8 @@ process_post(Req, #base_state{chef_db_context = DbContext,
         AllVersions ->
             case not_found_cookbooks(AllVersions, Cookbooks) of
                 ok ->
-                    Deps = chef_depsolver:solve_dependencies(AllVersions,
-                                                             EnvConstraints, Cookbooks),
+                    Deps = ?SH_TIME(ReqId, chef_depsolver, solve_dependencies,
+                                    (AllVersions, EnvConstraints, Cookbooks)),
                     handle_depsolver_results(ok, Deps, Req, State);
                 NotFound ->
                     %% We ignore Deps result if expanded run list contains missing


### PR DESCRIPTION
This patch aggregates calls to the chef_depsolver module (where
instrumented) as key "depsolver".

Instrumentation is added for the single call to chef_depsolver:solve
in chef_wm_depsolver.

Metrics should appear in both OSC and OPC.

Tested/confirmed in OPC dev-vm w/ smoke test.
