### PR TITLE
Add support for OPC reindexing

### DIFF
--- a/src/chef_reindex.erl
+++ b/src/chef_reindex.erl
@@ -34,35 +34,13 @@
 -type index() :: client | environment | node | role | binary().
 
 -export([
-         reindex/1
+         reindex/2
         ]).
 
 %% @doc Sends all indexed items (clients, data bag items,
 %% environments, nodes, and roles) from an organization to Solr for
 %% reindexing.  Does not drop existing index entries beforehand; this
 %% is explicitly a separate step.
--spec reindex(OrgName :: binary()) -> ok |
-                                      {error, {not_found, org}}.
-reindex(OrgName) ->
-    Ctx = chef_db:make_context(make_req_id()),
-    case chef_db:fetch_org_id(Ctx, OrgName) of
-        not_found ->
-            {error, {not_found, org}};
-        OrgId ->
-            reindex(Ctx, OrgId)
-    end.
-
-%% @doc Create a unique request ID.  Extracted from
-%% chef_wm_base:read_req_id/2 for the time being.
-%% @end
-%%
-%% TODO: Create a reqid() type
-%% TODO: Extract this function to a common location, and use it in chef_wm_base
--spec make_req_id() -> binary().
-make_req_id() ->
-    base64:encode(crypto:md5(term_to_binary(make_ref()))).
-
-%% @doc Implementation of reindex/1.
 -spec reindex(Ctx :: chef_db:db_context(),
               OrgId :: object_id()) -> ok.
 reindex(Ctx, OrgId) ->


### PR DESCRIPTION
This adds or supports a 'reindex-opc-organization' escript that can
reindex all the data from a Private Chef organization in a single user
operation.  It is analogous to the existing 'reindex-chef-server'
script for Open Source Chef.

A private-chef-ctl 'reindex' command has been added, which provides
the UI for the tool.

Changes were made to underlying code that makes the reindexing
possible, which is why open-source repositories are involved.

Both OPC and OSC builds have passed through CI.

The OPC Omnibus branch requires OPC 11 features to run; support for
pre-Chef 11 OPC servers is not provided.

See all PRs for this work  in the following repositories:

   chef-pedant, chef_wm, erchef, oc-chef-pedant, oc_chef_wm, oc_erchef, opscode-omnibus
