### PR TITLE
OC-9093: reqid logging

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
   %% to ensure we get mochiweb as specified by webmachine and not the
   %% one from gen_bunny.
   {opscoderl_wm, ".*",
-   {git, "git@github.com:opscode/opscoderl_wm.git", {branch, "master"}}},
+   {git, "git://github.com/opscode/opscoderl_wm.git", {branch, "master"}}},
 
   {chef_authn, ".*",
    {git, "git://github.com/opscode/chef_authn.git", {branch, "master"}}},

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -487,17 +487,10 @@ body_or_default(Req, Default) ->
     end.
 
 set_req_contexts(Req, #base_state{reqid_header_name = HeaderName} = State) ->
-    ReqId = read_req_id(HeaderName, Req),
+    ReqId = oc_wm_request:read_req_id(HeaderName, Req),
     DbContext = chef_db:make_context(ReqId),
     State#base_state{chef_db_context = DbContext, reqid = ReqId}.
 
-read_req_id(ReqHeaderName, Req) ->
-    case wrq:get_req_header(ReqHeaderName, Req) of
-        undefined ->
-            base64:encode(crypto:md5(term_to_binary(make_ref())));
-        HV ->
-            iolist_to_binary(HV)
-    end.
 
 spawn_stats_hero_worker(Req, #base_state{resource_mod = Mod,
                                          organization_name = OrgName,

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -182,14 +182,13 @@ content_types_accepted(Req, State) ->
 content_types_provided(Req, State) ->
     {[{"application/json", to_json}], Req, State}.
 
-finish_request(#wm_reqdata{req_headers = Headers} = Req,
-               #base_state{reqid = ReqId,
-                           organization_name = OrgName,
-                           darklaunch = Darklaunch}=State) ->
+finish_request(Req, #base_state{reqid = ReqId,
+                                organization_name = OrgName,
+                                darklaunch = Darklaunch}=State) ->
     try
         Code = wrq:response_code(Req),
         PerfTuples = stats_hero:snapshot(ReqId, agg),
-        UserId = mochiweb_headers:get_value("x-ops-userid", Headers),
+        UserId = wrq:get_req_header("x-ops-userid", Req),
         Req0 = oc_wm_request:add_notes([{req_id, ReqId},
                                         {user, UserId},
                                         {perf_stats, PerfTuples}], Req),


### PR DESCRIPTION
- Factored out annotation helpers
- Factored out reqid helpers
- Use latest refactored "better annotations" of opscoderl_wm

Requires:
- https://github.com/opscode/opscoderl_wm/pull/4
- https://github.com/opscode/omnibus-chef-server/pull/12
