### PR TITLE
Log Exceptions from Ruby Depsolver

### DIFF
--- a/src/chef_wm_depsolver.erl
+++ b/src/chef_wm_depsolver.erl
@@ -237,6 +237,13 @@ handle_depsolver_results(ok, {error, no_depsolver_workers}, Req, State) ->
             State,
             {[{<<"message">>,<<"Out of depednecy solvers. Try again later.">>}]},
             no_depsolver_workers);
+%% log the exception and return a bare 500
+handle_depsolver_results(ok, {error, exception, Message, Backtrace}, Req, State) ->
+    error_logger:error_report([{module, ?MODULE},
+                               {error_type, ruby_exception},
+                               {message, Message},
+                               {backtrace, Backtrace}]),
+    {{halt, 500}, Req, State};
 handle_depsolver_results(ok, {error, invalid_constraints, Detail}, Req, State) ->
     precondition_failed(Req, State,
                         invalid_constraints_message(Detail),


### PR DESCRIPTION
This change allows us to handle and log ruby exceptions at the chef_wm level, as well as return a 500 response code to the user. Here's an example of the error message:

```
=ERROR REPORT==== 16-Aug-2013::18:26:03 ===
    module: chef_wm_depsolver
    error_type: ruby_exception
    message: <<"'1.1.-2147483607' does not match 'x.y.z' or 'x.y'">>
    backtrace: [<<"/srv/piab/mounts/chef_objects/priv/depselector_rb/.bundle/ruby/1.9.1/bundler/gems/dep-selector-9f97b663e923/lib/dep_selector/version.rb:69:in `parse'">>,
                <<"/srv/piab/mounts/chef_objects/priv/depselector_rb/.bundle/ruby/1.9.1/bundler/gems/dep-selector-9f97b663e923/lib/dep_selector/version.rb:28:in `initialize'">>,
                <<"/srv/piab/mounts/oc_erchef/rel/oc_erchef/lib/chef_objects/priv/depselector_rb/depselector.rb:56:in `new'">>,
                <<"/srv/piab/mounts/oc_erchef/rel/oc_erchef/lib/chef_objects/priv/depselector_rb/depselector.rb:56:in `block (4 levels) in <main>'">>,
                <<"/srv/piab/mounts/oc_erchef/rel/oc_erchef/lib/chef_objects/priv/depselector_rb/depselector.rb:49:in `each'">>,
                <<"/srv/piab/mounts/oc_erchef/rel/oc_erchef/lib/chef_objects/priv/depselector_rb/depselector.rb:49:in `block (3 levels) in <main>'">>,
                <<"/srv/piab/mounts/oc_erchef/rel/oc_erchef/lib/chef_objects/priv/depselector_rb/depselector.rb:47:in `each'">>,
                <<"/srv/piab/mounts/oc_erchef/rel/oc_erchef/lib/chef_objects/priv/depselector_rb/depselector.rb:47:in `block (2 levels) in <main>'">>,
                <<"/srv/piab/mounts/chef_objects/priv/depselector_rb/.bundle/ruby/1.9.1/bundler/gems/erlectricity-b8b627fbc4b8/lib/erlectricity/matcher.rb:14:in `call'">>,
                <<"/srv/piab/mounts/chef_objects/priv/depselector_rb/.bundle/ruby/1.9.1/bundler/gems/erlectricity-b8b627fbc4b8/lib/erlectricity/matcher.rb:14:in `run'">>,
                <<"/srv/piab/mounts/chef_objects/priv/depselector_rb/.bundle/ruby/1.9.1/bundler/gems/erlectricity-b8b627fbc4b8/lib/erlectricity/receiver.rb:22:in `process'">>,
                <<"/srv/piab/mounts/chef_objects/priv/depselector_rb/.bundle/ruby/1.9.1/bundler/gems/erlectricity-b8b627fbc4b8/lib/erlectricity/receiver.rb:38:in `block in run'">>,
                <<"/srv/piab/mounts/chef_objects/priv/depselector_rb/.bundle/ruby/1.9.1/bundler/gems/erlectricity-b8b627fbc4b8/lib/erlectricity/receiver.rb:34:in `loop'">>,
                <<"/srv/piab/mounts/chef_objects/priv/depselector_rb/.bundle/ruby/1.9.1/bundler/gems/erlectricity-b8b627fbc4b8/lib/erlectricity/receiver.rb:34:in `run'">>,
                <<"/srv/piab/mounts/chef_objects/priv/depselector_rb/.bundle/ruby/1.9.1/bundler/gems/erlectricity-b8b627fbc4b8/lib/erlectricity/receiver.rb:67:in `receive'">>,
                <<"/srv/piab/mounts/oc_erchef/rel/oc_erchef/lib/chef_objects/priv/depselector_rb/depselector.rb:33:in `<main>'">>]
```

/cc @seth @marcparadise @manderson26 @oferrigni @hosh 
