### PR TITLE
OC-9346: log_msg

### DIFF
--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -93,7 +93,9 @@
           %% shared request logging code.
           %%
           %% Formatted using ~p, but expected to be reasonably small.
-          log_msg = "" :: term(),
+          %% If log_msg is remains undefined during finish_request,
+          %% then it won't be added into the log annotations.
+          log_msg = undefined :: term(),
 
           %% Time drift in seconds allowed between the timestamp in a
           %% singed request and the clock on the server.  Set in

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -192,7 +192,8 @@ finish_request(Req, #base_state{reqid = ReqId,
         Req0 = oc_wm_request:add_notes([{req_id, ReqId},
                                         {user, UserId},
                                         {perf_stats, PerfTuples}], Req),
-        AnnotatedReq = maybe_annotate_org_specific(OrgName, Darklaunch, Req0),
+        Req1 = maybe_annotate_log_msg(Req0, State),
+        AnnotatedReq = maybe_annotate_org_specific(OrgName, Darklaunch, Req1),
         stats_hero:report_metrics(ReqId, Code),
         stats_hero:stop_worker(ReqId),
         case Code of
@@ -534,6 +535,12 @@ maybe_annotate_org_specific(OrgName, Darklaunch, Req) ->
     DLData = chef_wm_darklaunch:get_proplist(Darklaunch),
     oc_wm_request:add_notes([{org_name, OrgName},
                              {darklaunch, DLData}], Req).
+
+%% Filters out log_msg that are undefined
+maybe_annotate_log_msg(Req, #base_state{log_msg = undefined}) ->
+    Req;
+maybe_annotate_log_msg(Req, #base_state{log_msg = Msg}) ->
+    oc_wm_request:add_notes([{msg, {raw, Msg}}], Req).
 
 %% If request results in a rename, then set Location header and wm will return with a 201.
 %% Currently, only the clients endpoint supports rename


### PR DESCRIPTION
Add log_msg to annotations as "msg"
- Changed default `log_msg` to `undefined`
  - If `log_msg` remains undefined when assembling the request log, then
    do not annotate the log with msg
  - Otherwise, use `{raw, Msg}` so we can see the Erlang term
  - This is a change from the old fast_log behavior. In the old
    behavior, if `log_msg` is not changed, then a `""` will be emitted into
    the log line as a `[]`. This is not a useful behavior and there is no
    known metric that depends on it.

Note: This PR does not contain the Ruby Depsolver work
