### PR TITLE
Flexible bulk_get using postgres arrays as WHERE id = ANY($1)

### DIFF
--- a/include/chef_wm.hrl
+++ b/include/chef_wm.hrl
@@ -117,11 +117,6 @@
           %% In OPC/OHC it will either contain dark launch info or no_header
           darklaunch = undefined :: any(), %% do not want to expose darklaunch record globally
 
-          %% Batch size used to pull back large objects from couchdb.
-          %% Currently used by the search resource to limit the number
-          %% of nodes that are in memory at one time.
-          batch_size = 5 :: non_neg_integer(),
-
           %% Opaque db connection context record as returned by
           %% chef_db:make_context.  Allows db layer access to request
           %% ID.  Set in chef_rest_wm:service_available

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -80,7 +80,6 @@ ping(Req, State) ->
 
 init_base_state(ResourceMod, InitParams) ->
     #base_state{reqid_header_name = ?gv(reqid_header_name, InitParams),
-                batch_size = ?gv(batch_size, InitParams),
                 auth_skew = ?gv(auth_skew, InitParams),
 
                 otp_info = ?gv(otp_info, InitParams),


### PR DESCRIPTION
Rather than implementing bulk_get queries as hard-coded prepared
queries via IN for 1, 2, 3, 4, or 5 items, we now use a Postgres array
as the query parameter and the ANY() function.

Accoding to this post [1](http://www.postgresql.org/message-id/5373.1158351561@sss.pgh.pa.us), the efficiency of the operation should be
equivalent to the IN approach.
