### PR TITLE
Of/oc 9686

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -39,7 +39,10 @@
    {git, "git://github.com/opscode/stats_hero.git", {branch, "master"}}},
 
   {folsom, ".*",
-   {git, "git://github.com/boundary/folsom.git", {tag, "0.7.2"}}}
+   {git, "git://github.com/boundary/folsom.git", {tag, "0.7.2"}}},
+  
+  {envy, ".*",
+   {git, "git@github.com:manderson26/envy.git", {branch, "master"}}}
 
  ]}.
 

--- a/src/chef_wm_enforce.erl
+++ b/src/chef_wm_enforce.erl
@@ -1,0 +1,48 @@
+-module(chef_wm_enforce).
+
+-export([
+         max_size/1
+        ]).
+
+-include("chef_wm.hrl").
+%% This is the max size allowed for incoming request bodies.
+-define(MAX_SIZE, 1000000).
+
+-spec max_size(#wm_reqdata{}) -> #wm_reqdata{}.
+%% Verify that the request body is not larger than ?MAX_SIZE bytes. Throws `{too_big, Msg}`
+%% if the request body is too large.
+max_size(Req) ->
+    case envy:get(chef_wm, max_request_size, ?MAX_SIZE, fun validate_size/1 )
+    of
+        disabled ->
+            Req;
+        TunedMaxSize ->
+            max_size(wrq:method(Req),Req, TunedMaxSize)
+    end.
+
+max_size(Method, Req, MaxSize) when Method =:= 'POST';
+                                    Method =:= 'PUT' ->
+    try
+        %% Force a read of request body. Webmachine memoizes this in the process
+        %% dictionary. Webmachine will read in chunks and call exit/1 if the body exceeds
+        %% the max set above. It would be nice if there was something other than a string to
+        %% match against. TODO:  webmachine.
+        wrq:req_body(wrq:set_max_recv_body(MaxSize, Req)),
+        Req
+    catch
+        exit:"request body too large" ->
+            Msg = iolist_to_binary([<<"JSON must be no more than ">>,
+                                    integer_to_list(MaxSize),
+                                    <<" bytes.">>]),
+            throw({too_big, Msg})
+    end;
+max_size(_Method, Req, _TunedMaxSize) ->
+    Req.
+
+validate_size(Integer) when is_integer(Integer) andalso Integer > 0 ->
+    true;
+
+validate_size(disabled) ->
+    true;
+validate_size(Value) ->
+    {invalid_value, Value, "value must be positive int or atom 'disabled'"}.

--- a/test/chef_wm_enforce_tests.erl
+++ b/test/chef_wm_enforce_tests.erl
@@ -1,0 +1,105 @@
+-module(chef_wm_enforce_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+max_size_test_() ->
+    DefaultMaxSize = 1000000,
+    TunedValue = 5,
+    [
+     {"Default tests",
+      {foreach,
+       fun() ->
+               meck:new(wrq),
+               application:unset_env(chef_wm, max_request_size)
+       end,
+       fun(_) ->
+               meck:unload(wrq)
+       end,
+       [
+        ?_test(max_size_success('POST', DefaultMaxSize)),
+        ?_test(max_size_success('PUT', DefaultMaxSize)),
+        ?_test(max_size_error('POST', DefaultMaxSize)),
+        ?_test(max_size_error('PUT', DefaultMaxSize))
+       ]
+      }
+     },
+     {"Tuned tests",
+      {foreach,
+       fun() ->
+
+               meck:new(wrq),
+               application:set_env(chef_wm, max_request_size, TunedValue)
+       end,
+       fun(_) ->
+               meck:unload(wrq),
+               application:unset_env(chef_wm, max_request_size)
+       end,
+       [
+        ?_test(max_size_success('POST', TunedValue)),
+        ?_test(max_size_success('PUT', TunedValue)),
+        ?_test(max_size_error('POST', TunedValue)),
+        ?_test(max_size_error('PUT', TunedValue))
+       ]
+      }
+     },
+     {"Disabled tests",
+      {foreach,
+       fun() ->
+               application:set_env(chef_wm, max_request_size, disabled)
+       end,
+       fun(_) ->
+               application:unset_env(chef_wm, max_request_size)
+       end,
+       [
+        fun(_) -> ?_test(disabled_max_size()) end
+       ]
+      }
+     },
+     {"Incorrect configuration tests",
+      {foreach,
+       fun() ->
+               application:unset_env(chef_wm, max_request_size)
+       end,
+       fun(_) ->
+               application:unset_env(chef_wm, max_request_size)
+       end,
+       [
+        ?_test(config_error(0)),
+        ?_test(config_error(-1)),
+        ?_test(config_error(not_disabled))
+       ]
+      }
+     }
+    ].
+
+max_size_success(Method, MaxSize) ->
+    meck:expect(wrq, method, 1, Method),
+    meck:expect(wrq, set_max_recv_body, 2, req),
+    meck:expect(wrq, req_body, 1, ignored),
+    ?assertEqual(req, chef_wm_enforce:max_size(req)),
+    ?assert(meck:called(wrq, set_max_recv_body, [MaxSize, req])).
+
+max_size_error(Method, MaxSize) ->
+    meck:expect(wrq, method, 1, Method),
+    meck:expect(wrq, set_max_recv_body, 2, req),
+    meck:expect(wrq, req_body, fun(_) -> exit("request body too large") end),
+    ErrorMessage = list_to_binary("JSON must be no more than " ++ integer_to_list(MaxSize) ++ " bytes."),
+    ?assertThrow({too_big, ErrorMessage  }, chef_wm_enforce:max_size(req)),
+    ?assert(meck:called(wrq, set_max_recv_body, [MaxSize, req])).
+
+disabled_max_size() ->
+    ?assertEqual(req, chef_wm_enforce:max_size(req)).
+
+config_error(Val) ->
+    application:set_env(chef_wm, max_request_size, Val),
+    ?assertError(config_bad_type, chef_wm_enforce:max_size(req)).
+
+max_size_when_get_should_return_req_test() ->
+    meck:new(wrq),
+    try
+        meck:expect(wrq, method, 1, 'GET'),
+        ?assertEqual(req, chef_wm_enforce:max_size(req)),
+        ?assert(meck:called(wrq, method, [req]))
+    after
+        meck:unload(wrq)
+    end.


### PR DESCRIPTION
Allow the max_request_size to be tuned via app.config.  In the absence of the config value, the original default of 1000000 is maintained.  If the config value is set to disabled, all requests will pass enforcement.  This PR also includes preliminary support for envy for application environment interrogation.
