### PR TITLE
OC-9691: Bring OSC builds up to date

### DIFF
--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -66,6 +66,7 @@ get_header_fun(Req, State = #base_state{header_fun = HFun})
                                end,
                         case wrq:get_req_header(string:to_lower(Name), Req) of
                             B when is_binary(B) -> B;
+                            "" -> undefined; %% We want to treat empty header values as missing
                             S when is_list(S) -> iolist_to_binary(S);
                             undefined -> undefined
                         end


### PR DESCRIPTION
Empty header value returns an undefined (treated the same as missing) 

Related:
- https://github.com/opscode/chef_db/pull/38
- https://github.com/opscode/omnibus-chef-server/pull/17
