### PR TITLE
[CHEF-4511] Update rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -42,7 +42,7 @@
    {git, "git://github.com/boundary/folsom.git", {tag, "0.7.2"}}},
   
   {envy, ".*",
-   {git, "git@github.com:manderson26/envy.git", {branch, "master"}}}
+   {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
 
  ]}.
 


### PR DESCRIPTION
I've encountered an error while running chef-server cookbook:

```
Pulling envy from {git,"git@github.com:manderson26/envy.git",
                       {branch,"master"}}
Cloning into 'envy'...
Host key verification failed.
fatal: The remote end hung up unexpectedly
ERROR: git clone -n git@github.com:manderson26/envy.git envy failed with error: 128 and output:
Cloning into 'envy'...
Host key verification failed.
fatal: The remote end hung up unexpectedly
```

Turned ':' to '/' in envy.git path
