### PR TITLE
CHEF-4086: Use "Host:" header value to construct returned URLs

### DIFF
--- a/src/chef_wm_cookbook_version.erl
+++ b/src/chef_wm_cookbook_version.erl
@@ -119,7 +119,7 @@ fetch_cookbook_version(DbContext, OrgName, Name, Version) ->
   chef_db:fetch_cookbook_version(DbContext, OrgName, {Name, Version}).
 
 to_json(Req, #base_state{resource_state=#cookbook_state{chef_cookbook_version=CBV}}=State) ->
-    CompleteEJson = chef_cookbook:assemble_cookbook_ejson(CBV),
+    CompleteEJson = chef_cookbook:assemble_cookbook_ejson(CBV, chef_wm_util:base_uri(Req)),
     {chef_json:encode(CompleteEJson), Req, State}.
 
 from_json(Req, #base_state{resource_state = CookbookState} = State) ->
@@ -159,7 +159,7 @@ delete_resource(Req, #base_state{chef_db_context = DbContext,
                                      chef_cookbook_version = CookbookVersion}
                                 } = State) ->
     ok = ?BASE_RESOURCE:delete_object(DbContext, CookbookVersion, RequestorId),
-    Json = chef_cookbook:assemble_cookbook_ejson(CookbookVersion),
+    Json = chef_cookbook:assemble_cookbook_ejson(CookbookVersion, chef_wm_util:base_uri(Req)),
     {true, chef_wm_util:set_json_body(Req, Json), State}.
 
 %% Private utility functions

--- a/src/chef_wm_depsolver.erl
+++ b/src/chef_wm_depsolver.erl
@@ -289,7 +289,7 @@ assemble_response(Req, State, CookbookVersions) ->
             %% cookbook which has just enough information for chef-client to run
             JsonList = {
                     [ { CBV#chef_cookbook_version.name,
-                       chef_cookbook:minimal_cookbook_ejson(CBV) }
+                       chef_cookbook:minimal_cookbook_ejson(CBV, chef_wm_util:base_uri(Req)) }
                       || CBV <- CookbookVersions ]
                     },
             CBMapJson = chef_json:encode(JsonList),

--- a/src/chef_wm_sandboxes.erl
+++ b/src/chef_wm_sandboxes.erl
@@ -109,7 +109,7 @@ sandbox_to_response(Req, #chef_sandbox{id = Id, org_id = OrgId, checksums = Chec
             {<<"uri">>, ?BASE_ROUTES:route(sandbox, Req, [{id, Id}])},
             {<<"checksums">>,
              {
-               [ {CSum, checksum_data(CSum, Flag, OrgId)} || {CSum, Flag} <- ChecksumList ]
+               [ {CSum, checksum_data(CSum, Flag, OrgId, chef_wm_util:base_uri(Req))} || {CSum, Flag} <- ChecksumList ]
              }
             }
            ]},
@@ -117,15 +117,15 @@ sandbox_to_response(Req, #chef_sandbox{id = Id, org_id = OrgId, checksums = Chec
 
 -define(PUT_URL_TTL, 900).
 
-checksum_data(_CSum, true, _OrgId) ->
+checksum_data(_CSum, true, _OrgId, _VHost) ->
     {[
       {<<"needs_upload">>, false}
      ]};
-checksum_data(CSum, false, OrgId) ->
+checksum_data(CSum, false, OrgId, VHost) ->
     %% FIXME: need to do a lookup either one at a time or in bulk to find out which
     %% checksums are already in the db.
     %% FIXME: will this be a problem for OSC w/ bookshelf?
-    PutUrl = chef_s3:generate_presigned_url(OrgId, ?PUT_URL_TTL, put, CSum),
+    PutUrl = chef_s3:generate_presigned_url(OrgId, ?PUT_URL_TTL, put, CSum, VHost),
     {[
       {<<"url">>, PutUrl},
       {<<"needs_upload">>, true}

--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -52,10 +52,17 @@ base_mods() ->
 
 %% @doc Returns the base URI for the server as called by the client as a string.
 base_uri(Req) ->
-    Scheme = scheme(Req),
-    Host = string:join(wrq:host_tokens(Req), "."),
-    PortString = port_string(wrq:port(Req)),
-    Scheme ++ "://" ++ Host ++ PortString.
+    scheme(Req) ++ "://" ++ vhost_or_peer(Req).
+
+%% @doc Returns the host from the request headers, or use the webmachine default
+vhost_or_peer(Req) ->
+    case wrq:get_req_header("host", Req) of
+        B when is_binary(B) -> binary_to_list(B);
+        S when is_list(S) -> S;
+        undefined ->
+            string:join(wrq:host_tokens(Req), ".") ++ port_string(wrq:port(Req))
+    end.
+
 
 get_header_fun(Req, State = #base_state{header_fun = HFun})
   when HFun =:= undefined ->

--- a/test/chef_wm_util_tests.erl
+++ b/test/chef_wm_util_tests.erl
@@ -1,0 +1,93 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(chef_wm_util_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+base_uri_test_() ->
+    HttpReq = wrq:create(get, "1.1", "/",
+        mochiweb_headers:from_binary([<<"Host: api.example.com:80\r\n">>])),
+    HttpsReq = wrq:create(get, https, "1.1", "/",
+        mochiweb_headers:from_binary([<<"Host: api.example.com:443\r\n">>])),
+    NoHostReq = wrq:create(get, https, "1.1", "/",
+        mochiweb_headers:from_binary([<<"Content-type: application/json\r\n">>])),
+    [
+        {"When base_resource_url is set to host_header",
+            {foreach,
+                fun() ->
+                        application:set_env(chef_wm, base_resource_url, host_header)
+                end,
+                fun(_) ->
+                        undefined %% noop
+                end,
+                [
+                    {"with http request",  ?_test(?assertEqual("http://api.example.com:80",chef_wm_util:base_uri(HttpReq)))},
+                    {"with https request", ?_test(?assertEqual("https://api.example.com:443",chef_wm_util:base_uri(HttpsReq)))},
+                    {"without Host: header",
+                        fun() ->
+                                meck:new(wrq, [passthrough]),
+                                meck:expect(wrq, host_tokens, 1, ["fake-s3", "com"]),
+                                meck:expect(wrq, port, 1, 80),
+                                ?assertEqual("https://fake-s3.com", chef_wm_util:base_uri(NoHostReq)),
+                                meck:unload(wrq)
+                        end
+                    }
+                ]
+            }
+        },
+        {"When base_resource_url is not set",
+            {foreach,
+                fun() ->
+                        application:unset_env(chef_wm, base_resource_url)
+                end,
+                fun(_) ->
+                        undefined %% noop
+                end,
+                [
+                    {"with http request",  ?_test(?assertEqual("http://api.example.com:80",chef_wm_util:base_uri(HttpReq)))},
+                    {"with https request", ?_test(?assertEqual("https://api.example.com:443",chef_wm_util:base_uri(HttpsReq)))},
+                    {"without Host: header",
+                        fun() ->
+                                meck:new(wrq, [passthrough]),
+                                meck:expect(wrq, host_tokens, 1, ["fake-s3", "com"]),
+                                meck:expect(wrq, port, 1, 80),
+                                ?assertEqual("https://fake-s3.com", chef_wm_util:base_uri(NoHostReq)),
+                                meck:unload(wrq)
+                        end
+                    }
+                ]
+            }
+        },
+        {"When base_resource_url is set to something",
+            fun() ->
+                    ExternalUrl = "https://fake-s3.com",
+                    application:set_env(chef_wm, base_resource_url, ExternalUrl),
+
+                    %% Regardless of request information, base_uri will return whatever
+                    %% is set to base_resource_url if it is a string
+                    ?assertEqual(ExternalUrl, chef_wm_util:base_uri(HttpReq)),
+                    ?assertEqual(ExternalUrl, chef_wm_util:base_uri(HttpsReq))
+            end
+        }
+    ].
+
+
+
+


### PR DESCRIPTION
- CHEF-4086: Use "Host:" header value to construct returned URLs

Requires:
- https://github.com/opscode/chef-pedant/pull/59
- https://github.com/opscode/chef_objects/pull/50
- https://github.com/opscode/omnibus-chef-server/pull/19

Notes:
- I did not include the case where Hosts: is empty (and not missing).
- How to even test this? Pedant won't catch all the cases, so additional unit testing is required.
