### PR TITLE
Convert to envy

### DIFF
--- a/src/chef_reindex.erl
+++ b/src/chef_reindex.erl
@@ -100,7 +100,7 @@ reindex(Ctx, {OrgId, _OrgName}=OrgInfo, Index) ->
     AllIds = dict:fold(fun(_K, V, Acc) -> [V|Acc] end,
                        [],
                        NameIdDict), %% All dict values will be unique anyway
-    {ok, BatchSize} = application:get_env(chef_wm, bulk_fetch_batch_size),
+    BatchSize = envy:get(chef_wm, bulk_fetch_batch_size, pos_integer),
     batch_reindex(Ctx, AllIds, BatchSize, OrgInfo, Index, NameIdDict).
 
 %% @doc Recursively batch-process a list of database IDs by retrieving

--- a/src/chef_wm_search.erl
+++ b/src/chef_wm_search.erl
@@ -168,19 +168,9 @@ to_json(Req, #base_state{chef_db_context = DbContext,
                 State#base_state{log_msg=Why}}
     end.
 
-%% Return current app config value for batch size. If value from config is not a positive
-%% integer or if the config key is missing, use a default value and log an error message.
+%% Return current app config value for batch size, defaulting if absent.
 batch_size() ->
-    case application:get_env(chef_wm, bulk_fetch_batch_size) of
-        {ok, BatchSize} when is_integer(BatchSize) andalso BatchSize > 0 ->
-            BatchSize;
-        undefined ->
-            error_logger:error_report({missing_config, {chef_wm, bulk_fetch_batch_size}, "using default"}),
-            ?DEFAULT_BATCH_SIZE;
-        {ok, BadSize} ->
-            error_logger:error_report({invalid_config, {chef_wm, bulk_fetch_batch_size, BadSize}, "using default"}),
-            ?DEFAULT_BATCH_SIZE
-    end.
+    envy:get(chef_wm, bulk_fetch_batch_size, ?DEFAULT_BATCH_SIZE, positive_integer).
 
 search_log_msg(not_found, SolrNumFound, NumIds, DbNumFound) ->
     {search, SolrNumFound, NumIds, DbNumFound};

--- a/src/chef_wm_status.erl
+++ b/src/chef_wm_status.erl
@@ -151,17 +151,8 @@ gather_health_workers([], Acc) ->
     Acc.
 
 ping_timeout() ->
-    case application:get_env(chef_wm, health_ping_timeout) of
-        {ok, Timeout} ->
-            Timeout;
-        _ ->
-            error({missing_config, {chef_wm, health_ping_timeout}})
-    end.
+    envy:get(chef_wm, health_ping_timeout, pos_integer).
 
 ping_modules() ->
-    case application:get_env(chef_wm, health_ping_modules) of
-        {ok, Modules} ->
-            Modules;
-        _ ->
-            error({missing_config, {chef_wm, health_ping_modules}})
-    end.
+    envy:get(chef_wm, health_ping_modules,list).
+


### PR DESCRIPTION
Application:get_env requires validation of data types.  This logic has been 
duplicated several times.  This attempts to consolidate validation to a single
library, envy.
