### PR TITLE
Updates for supporting containers

### DIFF
--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -292,7 +292,8 @@ verify_request_signature(Req,
 create_from_json(#wm_reqdata{} = Req,
                  #base_state{chef_db_context = DbContext,
                              organization_guid = OrgId,
-                             requestor_id = ActorId} = State,
+                             requestor_id = ActorId,
+                             resource_mod = ResourceMod} = State,
                  RecType, {authz_id, AuthzId}, ObjectEjson) ->
     %% ObjectEjson should already be normalized. Record creation does minimal work and does
     %% not add or update any fields.
@@ -314,7 +315,7 @@ create_from_json(#wm_reqdata{} = Req,
             chef_object_db:delete_from_solr(ObjectRec),
             %% FIXME: created authz_id is leaked for this case, cleanup?
             LogMsg = {RecType, name_conflict, Name},
-            ConflictMsg = conflict_message(TypeName, Name),
+            ConflictMsg = ResourceMod:conflict_message(Name),
             {{halt, 409}, chef_wm_util:set_json_body(Req, ConflictMsg),
              State#base_state{log_msg = LogMsg}};
         ok ->
@@ -344,7 +345,8 @@ object_creation_hook(Object, _State) -> Object.
 %% record. `ObjectEjson' is the parsed EJSON from the request body.
 update_from_json(#wm_reqdata{} = Req, #base_state{chef_db_context = DbContext,
                                                   organization_guid = OrgId,
-                                                  requestor_id = ActorId}=State,
+                                                  requestor_id = ActorId,
+                                                  resource_mod = ResourceMod} = State,
                  OrigObjectRec, ObjectEjson) ->
     ObjectRec = chef_object:update_from_ejson(OrigObjectRec, ObjectEjson),
 
@@ -382,7 +384,7 @@ update_from_json(#wm_reqdata{} = Req, #base_state{chef_db_context = DbContext,
                     TypeName = chef_object:type_name(ObjectRec),
                     RecType = erlang:element(1,ObjectRec),
                     LogMsg = {RecType, name_conflict, Name},
-                    ConflictMsg = conflict_message(TypeName, Name),
+                    ConflictMsg = ResourceMod:conflict_message(Name),
                     {{halt, 409}, chef_wm_util:set_json_body(Req, ConflictMsg),
                      State#base_state{log_msg = LogMsg}};
                 {error, {checksum_missing, Checksum}} ->
@@ -431,26 +433,6 @@ assemble_principal_ejson(#principal_state{name = Name,
       {<<"public_key">>, PublicKey},
       {<<"type">>, Type},
       {<<"authz_id">>, AuthzId}]}.
-
-conflict_message(cookbook_version, _Name) ->
-    {[{<<"error">>, [<<"Cookbook already exists">>]}]};
-conflict_message(role, _Name) ->
-    {[{<<"error">>, [<<"Role already exists">>]}]};
-conflict_message(node, _Name) ->
-    %% Msg = iolist_to_binary([<<"A node named '">>, Name, <<"' already exists.">>]),
-    Msg = <<"Node already exists">>,
-    {[{<<"error">>, [Msg]}]};
-conflict_message(data_bag_item, {BagName, ItemName}) ->
-    Msg = <<"Data Bag Item '", ItemName/binary, "' already exists in Data Bag '",
-            BagName/binary, "'.">>,
-    {[{<<"error">>, [Msg]}]};
-conflict_message(data_bag, _Name) ->
-    %% {[{<<"error">>, [<<"Data Bag '", Name/binary, "' already exists">>]}]}.
-    {[{<<"error">>, [<<"Data bag already exists">>]}]};
-conflict_message(environment, _Name) ->
-    {[{<<"error">>, [<<"Environment already exists">>]}]};
-conflict_message(client, _Name) ->
-    {[{<<"error">>, [<<"Client already exists">>]}]}.
 
 error_message(checksum_missing, Checksum) ->
     {[{<<"error">>, [iolist_to_binary([<<"Manifest has checksum ">>, Checksum,

--- a/src/chef_wm_clients.erl
+++ b/src/chef_wm_clients.erl
@@ -62,6 +62,7 @@
 -export([
          allowed_methods/2,
          create_path/2,
+         conflict_message/1,
          from_json/2
        ]).
 
@@ -136,3 +137,7 @@ from_json(Req, #base_state{reqid = RequestId,
 
 malformed_request_message(Any, Req, State) ->
     chef_wm_malformed:malformed_request_message(Any, Req, State).
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Client already exists">>]}]}.

--- a/src/chef_wm_cookbook_version.erl
+++ b/src/chef_wm_cookbook_version.erl
@@ -47,6 +47,7 @@
 -export([allowed_methods/2,
          delete_resource/2,
          from_json/2,
+         conflict_message/1,
          is_conflict/2,
          to_json/2]).
 
@@ -244,7 +245,9 @@ conflict_message(#chef_cookbook_version{name = Name,
     Msg = [<<"The cookbook ">>, Name, <<" at version ">>,
            chef_cookbook_version:version_to_binary({Major, Minor, Patch}),
            <<" is frozen. Use the 'force' option to override.">>],
-    {[{<<"error">>, [iolist_to_binary(Msg)]}]}.
+    {[{<<"error">>, [iolist_to_binary(Msg)]}]};
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Cookbook already exists">>]}]}.
 
 -spec is_forced(#wm_reqdata{}) ->  true | false.
 is_forced(Req) ->

--- a/src/chef_wm_data.erl
+++ b/src/chef_wm_data.erl
@@ -50,11 +50,11 @@
 
 -export([
          allowed_methods/2,
+         conflict_message/1,
          create_path/2,
          from_json/2,
          resource_exists/2
        ]).
-
 
 init(Config) ->
     chef_wm_base:init(?MODULE, Config).
@@ -103,3 +103,7 @@ from_json(Req, #base_state{resource_state =
 
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Data bag already exists">>]}]}.

--- a/src/chef_wm_environments.erl
+++ b/src/chef_wm_environments.erl
@@ -47,6 +47,7 @@
          validate_request/3]).
 
 -export([allowed_methods/2,
+         conflict_message/1,
          create_path/2,
          from_json/2,
          resource_exists/2]).
@@ -107,3 +108,7 @@ from_json(Req, #base_state{resource_state = EnvironmentState}=State) ->
 
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Environment already exists">>]}]}.

--- a/src/chef_wm_malformed.erl
+++ b/src/chef_wm_malformed.erl
@@ -76,6 +76,10 @@ malformed_request_message({client_name_mismatch}, _Req, _State) ->
 malformed_request_message({bad_client_name, Name, Pattern}, _Req, _State) ->
     {[{<<"error">>, [iolist_to_binary(["Invalid client name '", Name,
                                        "' using regex: '", Pattern, "'."])]}]};
+%% generic invalid name case
+malformed_request_message({bad_object_name, Name, Pattern}, _Req, _State) ->
+    {[{<<"error">>, [iolist_to_binary(["Invalid name '", Name,
+                                       "' using regex: '", Pattern, "'."])]}]};
 
 %% Not sure if we want to be this specific, or just want to fold this into an 'invalid JSON'
 %% case.  At any rate, here it is.

--- a/src/chef_wm_named_client.erl
+++ b/src/chef_wm_named_client.erl
@@ -47,6 +47,7 @@
 
 -export([
          allowed_methods/2,
+         conflict_message/1,
          delete_resource/2,
          from_json/2,
          to_json/2
@@ -154,3 +155,7 @@ maybe_generate_key_pair(ClientData, RequestId) ->
 
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Client already exists">>]}]}.

--- a/src/chef_wm_named_data_item.erl
+++ b/src/chef_wm_named_data_item.erl
@@ -49,6 +49,7 @@
 
 -export([
          allowed_methods/2,
+         conflict_message/1,
          delete_resource/2,
          from_json/2,
          resource_exists/2,
@@ -174,3 +175,9 @@ custom_404_msg(Req, BagName, ItemName) ->
         'DELETE' ->
             chef_wm_util:not_found_message(data_bag_item1, {BagName, ItemName})
     end.
+
+-spec conflict_message({binary(), binary()}) -> ejson_term().
+conflict_message({BagName, ItemName}) ->
+    Msg = <<"Data Bag Item '", ItemName/binary, "' already exists in Data Bag '",
+            BagName/binary, "'.">>,
+    {[{<<"error">>, [Msg]}]}.

--- a/src/chef_wm_named_environment.erl
+++ b/src/chef_wm_named_environment.erl
@@ -44,6 +44,7 @@
          validate_request/3]).
 
 -export([allowed_methods/2,
+         conflict_message/1,
          delete_resource/2,
          from_json/2,
          resource_exists/2,
@@ -121,3 +122,7 @@ delete_resource(Req, #base_state{chef_db_context = DbContext,
 
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Environment already exists">>]}]}.

--- a/src/chef_wm_nodes.erl
+++ b/src/chef_wm_nodes.erl
@@ -59,6 +59,7 @@
          validate_request/3]).
 
 -export([allowed_methods/2,
+         conflict_message/1,
          create_path/2,
          from_json/2,
          resource_exists/2,
@@ -147,3 +148,8 @@ package_node_list(NodeNames, Req, #base_state{}=State) ->
 
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    Msg = <<"Node already exists">>,
+    {[{<<"error">>, [Msg]}]}.

--- a/src/chef_wm_roles.erl
+++ b/src/chef_wm_roles.erl
@@ -51,6 +51,7 @@
          validate_request/3]).
 
 -export([allowed_methods/2,
+         conflict_message/1,
          create_path/2,
          from_json/2,
          resource_exists/2]).
@@ -99,3 +100,7 @@ from_json(Req, #base_state{resource_state =
 
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
+
+-spec conflict_message(binary()) -> ejson_term().
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Role already exists">>]}]}.


### PR DESCRIPTION
These updates refactor a bit of the functionality out of chef_wm_base and into the resource modules so that it becomes easier to add resources that `chef_wm` is unaware of. Those features are:
- standardize on 201 response code when a rename occurs on update
- conflict messaging is handled by the resource module

/cc @seth @oferrigni @hosh @marcparadise @manderson26 
