### PR TITLE
Add support for orphan authz cleanup

### DIFF
--- a/src/chef_wm_named_client.erl
+++ b/src/chef_wm_named_client.erl
@@ -133,7 +133,7 @@ delete_resource(Req, #base_state{chef_db_context = DbContext,
                                  resource_state = #client_state{
                                    chef_client = Client},
                                  organization_name = OrgName} = State) ->
-    ok = chef_object_db:delete(DbContext, Client, RequestorId),
+    ok = ?BASE_RESOURCE:delete_object(DbContext, Client, RequestorId),
     EJson = chef_client:assemble_client_ejson(Client, OrgName),
     Req1 = chef_wm_util:set_json_body(Req, EJson),
     {true, Req1, State}.

--- a/src/chef_wm_named_data.erl
+++ b/src/chef_wm_named_data.erl
@@ -195,7 +195,7 @@ delete_resource(Req, #base_state{chef_db_context = DbContext,
                                      data_bag_name = DataBagName}
                                 } = State) ->
 
-    ok = chef_object_db:delete(DbContext, DataBag, RequestorId),
+    ok = ?BASE_RESOURCE:delete_object(DbContext, DataBag, RequestorId),
     NakedBag = {[{<<"name">>, DataBagName},
                  {<<"json_class">>, <<"Chef::DataBag">>},
                  {<<"chef_type">>, <<"data_bag">>}]},

--- a/src/chef_wm_named_data_item.erl
+++ b/src/chef_wm_named_data_item.erl
@@ -153,7 +153,7 @@ delete_resource(Req, #base_state{chef_db_context = DbContext,
                                      chef_data_bag_item = Item}
                                 }=State) ->
 
-    ok = chef_object_db:delete(DbContext, Item, RequestorId),
+    ok = ?BASE_RESOURCE:delete_object(DbContext, Item, RequestorId),
     Json = chef_db_compression:decompress(Item#chef_data_bag_item.serialized_object),
     EjsonItem = chef_json:decode(Json),
     WrappedItem = chef_data_bag_item:wrap_item(BagName, ItemName, EjsonItem),

--- a/src/chef_wm_named_user.erl
+++ b/src/chef_wm_named_user.erl
@@ -116,7 +116,7 @@ delete_resource(Req, #base_state{chef_db_context = DbContext,
                                  resource_state = #user_state{
                                    chef_user = User},
                                  organization_name = OrgName} = State) ->
-    ok = chef_object_db:delete(DbContext, User, RequestorId),
+    ok = ?BASE_RESOURCE:delete_object(DbContext, User, RequestorId),
     EJson = chef_user:assemble_user_ejson(User, OrgName),
     Req1 = chef_wm_util:set_json_body(Req, EJson),
     {true, Req1, State}.


### PR DESCRIPTION
In the course of operations, it is possible to orphan authz ids.  These authz
ids can be members of groups.  These changes both lower the frequency of
orphaning authz ids and provide functionality to remove existing orphans from
bifrost upon detection.

There are new configuration elements for this cleanup.  In oc_chef_authz
cleanup_interval specifies the time between checks for orphans to be cleaned
up.  Additionally in oc_chef_authz, cleanup_batch_size specifies the number of
orphans to cleanup per interval event.

The intervals should not stack.  A timer activates on the interval time and,
once the prune task completes, is scheduled again.  This keeps the time between
cleanups consistent.
