### PR TITLE
Use lager instead of fastlog

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -32,9 +32,6 @@
   {bcrypt, ".*",
    {git, "git://github.com/opscode/erlang-bcrypt.git", {tag, "0.5.0.3"}}},
 
-  {fast_log, ".*",
-   {git, "git://github.com/opscode/fast-log-erlang.git", {branch, "master"}}},
-
   {mixer, ".*",
    {git, "git://github.com/opscode/mixer.git", {tag, "0.1.1"}}},
 
@@ -43,11 +40,17 @@
 
   {folsom, ".*",
    {git, "git://github.com/boundary/folsom.git", {tag, "0.7.2"}}},
-  
+
   {envy, ".*",
    {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
 
  ]}.
 
+%% rebar.config.script is used by rebar to merge these erl_opts with
+%% subordinate projects so that subordinate projects can set BASE_RESOURCE
+%% and BASE_ROUTES macros, if needed, since rebar only allows overriding these
+%% if the subordinate project does not itself set an erl_opts option in its
+%% config
 {erl_opts, [{parse_transform, lager_transform}]}.
+
 {cover_enabled, true}.

--- a/src/chef_reindex.erl
+++ b/src/chef_reindex.erl
@@ -130,7 +130,7 @@ reindex_by_name(Ctx, {OrgId, _OrgName} = OrgInfo, Index, Names) ->
                         {ok, Id} ->
                             [Id | Acc];
                         error ->
-                            error_logger:warning_msg("skipping: no id found for name ~p", [Name]),
+                            lager:warning("skipping: no id found for name ~p", [Name]),
                             Acc
                     end
             end, [], Names),

--- a/src/chef_wm.app.src
+++ b/src/chef_wm.app.src
@@ -26,7 +26,7 @@
                   crypto,
                   bcrypt,
                   stats_hero,
-                  fast_log,
+                  lager,
                   sqerl,
                   gen_bunny,
                   ibrowse,

--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -140,7 +140,7 @@ malformed_request(Req, #base_state{resource_mod=Mod,
             Req3 = wrq:set_resp_body(chef_json:encode(Msg1), Req),
             {{halt, 400}, Req3, State1#base_state{log_msg = bad_sign_desc}};
         throw:{too_big, Msg} ->
-            error_logger:info_msg("json too large (~p)", [Msg]),
+            lager:info("json too large (~p)", [Msg]),
             Req3 = wrq:set_resp_body(chef_json:encode({[{<<"error">>, Msg}]}), Req),
             {{halt, 413}, Req3, State1#base_state{log_msg = too_big}};
         throw:Why ->
@@ -207,7 +207,7 @@ finish_request(Req, #base_state{reqid = ReqId,
         end
     catch
         X:Y ->
-            error_logger:error_report({X, Y, erlang:get_stacktrace()})
+            lager:error({X, Y, erlang:get_stacktrace()})
     end.
 
 create_500_response(Req, State) ->
@@ -495,7 +495,7 @@ spawn_stats_hero_worker(Req, #base_state{resource_mod = Mod,
         {ok, _} ->
             ok;
         {error, Reason} ->
-            error_logger:error_msg("FAILED stats_hero_worker_sup:new_worker: ~p~n",
+            lager:error("FAILED stats_hero_worker_sup:new_worker: ~p~n",
                                    [Reason]),
             ok
     end.
@@ -556,7 +556,7 @@ select_user_or_webui_key(Req, Requestor) ->
                             %% The proplist for webui_pub_key_list has been parsed, so the
                             %% key should exist as an atom
                             throw:badarg ->
-                                error_logger:error_report({"unknown webkey tag", Tag,
+                                lager:error({"unknown webkey tag", Tag,
                                                            erlang:get_stacktrace()}),
                                 %% alternately, we could just use the default key instead of failing;
                                 %% but I prefer noisy errors
@@ -571,7 +571,7 @@ select_user_or_webui_key(Req, Requestor) ->
                     PublicKey;
                 {error, unknown_key} ->
                     Msg = io_lib:format("Failed finding key ~w", [WebKeyTag]),
-                    error_logger:error_report({no_such_key, Msg, erlang:get_stacktrace()}),
+                    lager:error({no_such_key, Msg, erlang:get_stacktrace()}),
                     throw({no_such_key, WebKeyTag})
             end;
         _Else ->

--- a/src/chef_wm_depsolver.erl
+++ b/src/chef_wm_depsolver.erl
@@ -111,7 +111,7 @@ process_post(Req, #base_state{reqid = ReqId,
     EnvConstraints = chef_object_base:depsolver_constraints(Env),
     case chef_db:fetch_all_cookbook_version_dependencies(DbContext, OrgName) of
         {error, Error} ->
-            error_logger:error_msg("Dependency retrieval failure for org ~p with environment ~p: ~p~n",
+            lager:error("Dependency retrieval failure for org ~p with environment ~p: ~p~n",
                                    [OrgName, EnvName, Error]),
             server_error(Req, State, <<"Dependency retrieval failed">>, dep_retrieval_failure);
         AllVersions ->
@@ -235,7 +235,7 @@ handle_depsolver_results(ok, {error, no_depsolver_workers}, Req, State) ->
             no_depsolver_workers);
 %% log the exception and return a 500
 handle_depsolver_results(ok, {error, exception, Message, Backtrace}, Req, State) ->
-    error_logger:error_report([{module, ?MODULE},
+    lager:error([{module, ?MODULE},
                                {error_type, depsolver_ruby_exception},
                                {message, Message},
                                {backtrace, Backtrace}]),

--- a/src/chef_wm_status.erl
+++ b/src/chef_wm_status.erl
@@ -74,7 +74,7 @@ overall_status(Pings) ->
 -spec log_failure(fail | pong, [{binary(), <<_:32>>}]) -> ok.
 log_failure(fail, Pings) ->
     FailureData = {{status, fail}, {upstreams, {Pings}}},
-    error_logger:error_msg("/_status~n~p~n", [FailureData]),
+    lager:error("/_status~n~p~n", [FailureData]),
     ok;
 log_failure(_,_) ->
     ok.
@@ -144,7 +144,7 @@ gather_health_workers([{{Pid, _}, Mod} | Rest] = List, Acc) ->
         %% crash. But to avoid the possibility of blocking with a bare receive, we set the
         %% timeout and return early.
         Timeout ->
-            error_logger:error_report({Mod, ping, hard_fail}),
+            lager:error({Mod, ping, hard_fail}),
             [ {?A2B(Mod), <<"fail">>} | Acc ]
     end;
 gather_health_workers([], Acc) ->


### PR DESCRIPTION
Update the rebar config erl_opts to include the lager transform
Update error_log calls to use lager directly
  This isn't strictly necessary, as lager will catch error_log calls
  since error_log is just a gen event and we've turned this
  functionality on; however. we get more lager functionality using it
  directly

It's unclear to me if the change to erl_opts here is proper or not. I appreciate some clarification on it. Also see the PR and comments left on erchef here: https://github.com/opscode/erchef/pull/19
