### PR TITLE
databag item create: cleanup solr on conflict

### DIFF
--- a/src/chef_wm_routes.erl
+++ b/src/chef_wm_routes.erl
@@ -84,6 +84,7 @@ route(node, Req, Args) -> route_rest_object("nodes", Req, Args);
 route(role, Req, Args) -> route_rest_object("roles", Req, Args);
 route(user, Req, Args) -> route_rest_object("users", Req, Args);
 route(data_bag, Req, Args) -> route_rest_object("data", Req, Args);
+route(data_bag_item, Req, [{name, {DataBagName, _}}]) -> route(data_bag, Req, [{name, DataBagName}]);
 route(environment, Req, Args) -> route_rest_object("environments", Req, Args);
 route(principal, Req, Args) -> route_rest_object("principals", Req, Args);
 route(client, Req, Args) -> route_rest_object("clients", Req, Args);


### PR DESCRIPTION
This fixes the odd search behavior in Chef where we are seeing multiple search results from Solr that match for a single item. These search results have bogus IDs that don't reference an item in the database, but after time can cause long paging search queries for searches that should return one item.
