### PR TITLE
Handle exceptions, throws, and exits from chef_solr

### DIFF
--- a/src/chef_wm_search.erl
+++ b/src/chef_wm_search.erl
@@ -66,9 +66,7 @@
          to_json/2]).
 
 -ifdef(TEST).
--export([
-        spawn_solr_query/4         
-        ]).
+-compile([export_all]).
 -endif.
 
 init(Config) ->

--- a/src/chef_wm_search.erl
+++ b/src/chef_wm_search.erl
@@ -65,6 +65,12 @@
          resource_exists/2,
          to_json/2]).
 
+-ifdef(TEST).
+-export([
+        spawn_solr_query/4         
+        ]).
+-endif.
+
 init(Config) ->
     chef_wm_base:init(?MODULE, Config).
 
@@ -255,10 +261,16 @@ spawn_solr_query(Label, Url, Query, ReqId) ->
     Parent = self(),
     proc_lib:spawn_link(
       fun() ->
-              Result = stats_hero:ctime(ReqId, {chef_solr, Label},
-                                        fun() ->
-                                                chef_solr:search(Query, Url)
-                                        end),
+              Result =
+                  try
+                      stats_hero:ctime(ReqId, {chef_solr, Label},
+                                       fun() ->
+                                               chef_solr:search(Query, Url)
+                                       end)
+                  catch
+                      Error:Reason ->
+                          {Error, Reason}
+                  end,
               Parent ! {self(), Result}
       end).
 

--- a/test/chef_wm_search_tests.erl
+++ b/test/chef_wm_search_tests.erl
@@ -1,0 +1,74 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+
+
+-module(chef_wm_search_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-compile([export_all]).
+
+search_test_() ->
+    {foreach,
+     fun() ->
+             meck:new(chef_solr)
+     end,
+     fun(_) ->
+             meck:unload([chef_solr])
+     end,
+     [
+      {"Catch exception and return",
+       fun() ->
+               meck:expect(chef_solr, search,
+                           fun(solr_query, url) ->
+                                   erlang:error(any_error)
+                           end
+                          ),
+
+               ?assertMatch({_, {error, any_error}},exec_chef_solr())
+       end},
+       {"Catch throw and return",
+       fun() ->
+               meck:expect(chef_solr, search,
+                           fun(solr_query, url) ->
+                                   erlang:throw({other, any_error})
+                           end
+                          ),
+
+               ?assertMatch({_, {throw, {other, any_error}}},exec_chef_solr())
+       end},
+       {"Catch exit and return",
+       fun() ->
+               meck:expect(chef_solr, search,
+                           fun(solr_query, url) ->
+                                   erlang:exit(any_error)
+                           end
+                          ),
+
+               ?assertMatch({_, {exit, any_error}},exec_chef_solr())
+       end},
+
+      {"Return result when no error",
+       fun() ->
+               meck:expect(chef_solr, search,
+                           fun(solr_query, url) ->
+                                   result
+                           end
+                          ),
+               meck:expect(stats_hero, ctime, fun(_, _, Fun) ->
+                                                      Fun()
+                                              end),
+               ?assertMatch({_, result},exec_chef_solr())
+
+       end}
+     ]}.
+
+exec_chef_solr() ->
+    begin
+        chef_wm_search:spawn_solr_query(label, url, solr_query, req_id),
+        receive
+            Val ->
+                Val
+        end
+    end.
+    


### PR DESCRIPTION
This will convert any exception, throw or exit from the spawn_linked query
process to an error tuple.
