### PR TITLE
initial pass: users endpoint in oc_erchef

### DIFF
--- a/src/chef_wm_base.erl
+++ b/src/chef_wm_base.erl
@@ -292,6 +292,12 @@ verify_request_signature(Req,
 %% (e.g. `chef_node'). `ContainerId' is the AuthzID of the container for the object being
 %% created (e.g. node container authz ID for creating a node). The `ObjectEjson' is the
 %% validated and normalized EJSON that was parsed from the request body.
+create_from_json(#wm_reqdata{} = Req, #base_state{organization_guid = undefined} = State,
+                                                  RecType, AuthzData, ObjectEJson) ->
+    % For objects that are not a member of an org, we just need to provide a valid ID
+    % for guid generation.
+    create_from_json(Req, State#base_state{organization_guid = ?OSC_ORG_ID},
+                     RecType, AuthzData, ObjectEJson);
 create_from_json(#wm_reqdata{} = Req,
                  #base_state{chef_db_context = DbContext,
                              organization_guid = OrgId,

--- a/src/chef_wm_password.erl
+++ b/src/chef_wm_password.erl
@@ -27,8 +27,13 @@
 -compile([export_all]).
 -endif.
 
--define(DEFAULT_HASH_TYPE, <<"erlang-bcrypt-0.5.0">>).
--define(MIGRATION_HASH_TYPE, <<"sha1+bcrypt">>).
+-ifndef(DEFAULT_HASH_TYPE).
+-define(DEFAULT_HASH_TYPE, 'erlang-bcrypt-0.5.0').
+-endif.
+
+-ifndef(MIGRATION_HASH_TYPE).
+-define(MIGRATION_HASH_TYPE, 'sha1+bcrypt"').
+-endif.
 
 -type str_or_bin() :: string() | binary().
 

--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -94,6 +94,8 @@ get_header_fun(Req, State = #base_state{header_fun = HFun})
 get_header_fun(_Req, State) ->
     {State#base_state.header_fun, State}.
 
+fetch_org_guid(#base_state{organization_name = undefined}) ->
+    undefined;
 fetch_org_guid(#base_state{organization_guid = Id}) when is_binary(Id) ->
     Id;
 fetch_org_guid(#base_state{organization_guid = undefined,
@@ -363,4 +365,4 @@ lists_diff_sorted(FirstList, SecondList) ->
     {lists:sort(sets:to_list(sets:subtract(FirstSet, SecondSet))),
      lists:sort(sets:to_list(sets:subtract(SecondSet, FirstSet)))}.
 
-    
+

--- a/src/chef_wm_util.erl
+++ b/src/chef_wm_util.erl
@@ -30,7 +30,6 @@
          get_header_fun/2,
          fetch_org_guid/1,
          malformed_request_message/3,
-         admin_field_is_false/1,
          base_mods/0,
          not_found_message/2,
          num_versions/1,
@@ -272,10 +271,6 @@ malformed_request_message(#ej_invalid{type = object_value, key = Object, found =
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
 
-admin_field_is_false(#chef_user{admin = Admin}) when Admin =:= false ->
-  true;
-admin_field_is_false(#chef_user{}) ->
-  false.
 
 %% @doc Utility function to process the `num_versions' parameter that is common to several
 %% cookbook-related resources


### PR DESCRIPTION
- includes users endpoint support in erchef
- support in underyling components for oc_chef_wm requests
  that do not have a valid org, without stubbing out org.
- make oc_erchef aware of global containers in couch
- nginx routing for endpoints

/ping @opscode/server-team

Note that I'm leaning towards maintaining this as a feature branch
pending completion of other works in progress.
