### PR TITLE
allow verify/2 to accept atom for encryption type

### DIFF
--- a/src/chef_wm_password.erl
+++ b/src/chef_wm_password.erl
@@ -60,7 +60,9 @@ encrypt(Password) ->
       Password :: str_or_bin(),
       HashedPass :: str_or_bin(),
       Salt :: str_or_bin(),
-      HashType :: str_or_bin().
+      HashType :: str_or_bin() | atom().
+verify(Password, {HashedPass, Salt, HashType}) when is_binary(HashType) ->
+    verify(Password, {HashedPass, Salt, binary_to_atom(HashType, utf8)});
 verify(Password, {HashedPass, Salt, ?DEFAULT_HASH_TYPE}) ->
     {ok, ThisHashedPass} = bcrypt:hashpw(to_str(Password), to_str(Salt)),
     slow_compare(ThisHashedPass, to_str(HashedPass));


### PR DESCRIPTION
ping @opscode/server-team 

In order to work around an issue in erlang compiler which prevents us
from specificying {d, value, <<"abinary">>}.  as a compiler option in rebar.config,
we needed to set default encryption types to be an atom. - this change
allows verify/2 to convert a received binary string to atom to prevent
match failures.
