### PR TITLE
verify_password can use salt encoded w/ bcrypt password

### DIFF
--- a/src/chef_wm_password.erl
+++ b/src/chef_wm_password.erl
@@ -27,13 +27,8 @@
 -compile([export_all]).
 -endif.
 
--ifndef(DEFAULT_HASH_TYPE).
--define(DEFAULT_HASH_TYPE, 'erlang-bcrypt-0.5.0').
--endif.
-
--ifndef(MIGRATION_HASH_TYPE).
--define(MIGRATION_HASH_TYPE, 'sha1+bcrypt"').
--endif.
+-define(DEFAULT_HASH_TYPE, <<"bcrypt">>).
+-define(MIGRATION_HASH_TYPE, <<"SHA1-bcrypt">>).
 
 -type str_or_bin() :: string() | binary().
 
@@ -61,8 +56,6 @@ encrypt(Password) ->
       HashedPass :: str_or_bin(),
       Salt :: str_or_bin(),
       HashType :: str_or_bin() | atom().
-verify(Password, {HashedPass, Salt, HashType}) when is_binary(HashType) ->
-    verify(Password, {HashedPass, Salt, binary_to_atom(HashType, utf8)});
 verify(Password, {HashedPass,<<"">>, ?DEFAULT_HASH_TYPE}) ->
     % the bcrypt library will automatically use the salt portion of the hashed password
     % string, so pass the entire thing as the salt value.

--- a/src/chef_wm_password.erl
+++ b/src/chef_wm_password.erl
@@ -63,12 +63,15 @@ encrypt(Password) ->
       HashType :: str_or_bin() | atom().
 verify(Password, {HashedPass, Salt, HashType}) when is_binary(HashType) ->
     verify(Password, {HashedPass, Salt, binary_to_atom(HashType, utf8)});
+verify(Password, {HashedPass,<<"">>, ?DEFAULT_HASH_TYPE}) ->
+    % the bcrypt library will automatically use the salt portion of the hashed password
+    % string, so pass the entire thing as the salt value.
+    verify(Password, {HashedPass, HashedPass, ?DEFAULT_HASH_TYPE});
 verify(Password, {HashedPass, Salt, ?DEFAULT_HASH_TYPE}) ->
     {ok, ThisHashedPass} = bcrypt:hashpw(to_str(Password), to_str(Salt)),
     slow_compare(ThisHashedPass, to_str(HashedPass));
 verify(Password, {HashedPass, Salt, ?MIGRATION_HASH_TYPE}) ->
     verify_sha1_bcrypt(Password, HashedPass, Salt).
-
 verify_sha1_bcrypt(Password, HashedPass, Salt) ->
     {OrigSalt, BcryptSalt} = parse_salt(Salt),
     %% sha takes an iolist

--- a/test/chef_wm_password_tests.erl
+++ b/test/chef_wm_password_tests.erl
@@ -66,6 +66,13 @@ bcrypt_round_trip_test_() ->
                  || {P, Data} <- PassData ]
        end},
 
+      {"salt not specified roundtrip",
+       fun() ->
+               P = "a long password",
+               {Hash, _, Type} = chef_wm_password:encrypt(P),
+               ?assertEqual(true, chef_wm_password:verify(P, {Hash, <<>>, Type}))
+       end},
+
       {"wrong password is wrong",
        fun() ->
                ?assertEqual(false,
@@ -74,7 +81,7 @@ bcrypt_round_trip_test_() ->
        end}
 
      ]}.
-    
+
 
 
 %% Example data generated with the Ruby code found at the bottom of


### PR DESCRIPTION
ping @opscode/server-team 

Under opscode-account, users both newly created and with updated bcrypt
passwords have an empty string stored for salt, because the
bcrypt modular format for the hashed password also includes the
salt.

With this change, when the salt is empty, we will use the encoded
modular bcrypt format in its place - the bcrypt library will use
only the salt portion of the hashed password.
