### PR TITLE
chef_wm_password supports both EC and OSC password data schemas

### DIFF
--- a/test/password_gen.rb
+++ b/test/password_gen.rb
@@ -1,0 +1,36 @@
+require "digest"
+class ShaHasher
+  def self.generate_salt
+    salt = Time.now.to_s
+    chars = ("a".."z").to_a + ("A".."Z").to_a + ("0".."9").to_a
+    1.upto(30) { |i| salt << chars[rand(chars.size-1)] }
+    salt
+  end
+
+  def self.encrypt_password(password, salt, type)
+    case type
+      when "osc"
+        Digest::SHA1.hexdigest("--#{salt}--#{password}--")
+      when "ec"
+        Digest::SHA1.hexdigest("#{salt}--#{password}--")
+    end
+  end
+
+  def self.make_examples(words)
+    ["osc", "ec"].each do |type|
+      puts "{ #{type}, ["
+      words.each do |w|
+        s = self.generate_salt
+        puts self.fmt_entry(w, self.encrypt_password(w, s, type), s)
+      end
+      puts "]}."
+    end
+  end
+
+  def self.fmt_entry(pass, hash, salt)
+    '{<<"%s">>, <<"%s">>, <<"%s">>}' % [pass, hash, salt]
+  end
+end
+
+words = ["a", "b", "fizzbuz", "sesame", "apple"]
+ShaHasher.make_examples(words)


### PR DESCRIPTION
- Add support for EC/OSC sha1+bcrypt types
- support forlegacy sha1+salt types
- upgrade function
- tests for the above
- added a password test data generator rb file

ping @opscode/server-team 
