### PR TITLE
Use chef_keygen_cache for obtaining key pairs for users and clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ DIALYZER_DEPS = deps/chef_authn/ebin \
                 deps/stats_hero/ebin \
                 deps/ibrowse/ebin \
                 deps/webmachine/ebin \
-                deps/jiffy/ebin \
-                deps/chef_certgen/ebin
+                deps/jiffy/ebin
+
 DEPS_PLT = chef_wm.plt
 
 all: compile eunit dialyzer

--- a/rebar.config
+++ b/rebar.config
@@ -17,9 +17,6 @@
   {chef_authn, ".*",
    {git, "git://github.com/opscode/chef_authn.git", {branch, "master"}}},
 
-  {chef_certgen, ".*",
-   {git, "git://github.com/opscode/chef_certgen.git", {branch, "master"}}},
-
   {chef_db, ".*",
    {git, "git://github.com/opscode/chef_db.git", {branch, "master"}}},
 

--- a/src/chef_wm_status.erl
+++ b/src/chef_wm_status.erl
@@ -60,7 +60,11 @@ check_health() ->
     Pings = spawn_health_checks(),
     Status = overall_status(Pings),
     log_failure(Status, Pings),
-    {Status, chef_json:encode({[{<<"status">>, ?A2B(Status)}, {<<"upstreams">>, {Pings}}]})}.
+    KeyGen = chef_keygen_cache:status(),
+    {Status, chef_json:encode({[{<<"status">>, ?A2B(Status)},
+                                {<<"upstreams">>, {Pings}},
+                                {<<"keygen">>, {KeyGen} }
+                               ]})}.
 
 overall_status(Pings) ->
     case [ Pang || {_, <<"fail">>}=Pang <- Pings ] of

--- a/src/chef_wm_sup.erl
+++ b/src/chef_wm_sup.erl
@@ -81,11 +81,19 @@ init([]) ->
                {chef_keyring, start_link, []},
                permanent, brutal_kill, worker, [chef_keyring]},
 
+    KeyGenWorkerSup = {chef_keygen_worker_sup,
+                       {chef_keygen_worker_sup, start_link, []},
+                       permanent, 5000, supervisor, [chef_keygen_worker_sup]},
+
+    KeyCache = {chef_keygen_cache,
+                {chef_keygen_cache, start_link, []},
+                permanent, 5000, worker, [chef_keygen_cache]},
+
     Index = {chef_index_sup,
              {chef_index_sup, start_link, []},
              permanent, 5000, supervisor, [chef_index_sup]},
 
-    Processes = [Folsom, KeyRing, Web, Index],
+    Processes = [Folsom, KeyRing, Index, KeyGenWorkerSup, KeyCache, Web],
     {ok, { {one_for_one, 10, 10}, Processes} }.
 
 add_custom_settings(Dispatch) ->


### PR DESCRIPTION
See opscode/chef_authn#13

This was updated a bit from that due to the recent changes to the users endpoints.
- Wire keygen cache into supervision tree
- Replace chef_wm_util:generate_keypair/2 with
  chef_wm_util:maybe_generate_key_pair/1 which is now used in
  chef_wm_named_client.
- Catch keygen_timeout in clients endpoints. Return 503 for this case
  with log message set to 'keygen_timeout'
- Remove dependency on chef_certgen

@seth  @sdelano @marcparadise @doubt72
