### PR TITLE
Fix status report when key generation is inflight

### DIFF
--- a/src/chef_wm_status.erl
+++ b/src/chef_wm_status.erl
@@ -60,7 +60,7 @@ check_health() ->
     Pings = spawn_health_checks(),
     Status = overall_status(Pings),
     log_failure(Status, Pings),
-    KeyGen = chef_keygen_cache:status(),
+    KeyGen = chef_keygen_cache:status_for_json(),
     {Status, chef_json:encode({[{<<"status">>, ?A2B(Status)},
                                 {<<"upstreams">>, {Pings}},
                                 {<<"keygen">>, {KeyGen} }


### PR DESCRIPTION
This is a pain to test because it fails only when we are actively generating keys.

@oferrigni @marcparadise @sdelano @tylercloke @doubt72 @jmink
