### PR TITLE
Corrected chef_db to use master instead of  ma/fetch_org_authz branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
    {git, "git://github.com/opscode/chef_authn.git", {branch, "master"}}},
 
   {chef_db, ".*",
-   {git, "git://github.com/opscode/chef_db.git", {branch, "ma/fetch_org_authz"}}},
+   {git, "git://github.com/opscode/chef_db.git", {branch, "master"}}},
 
   {chef_index, ".*",
    {git, "git://github.com/opscode/chef_index.git", {branch, "master"}}},


### PR DESCRIPTION
Trivial I hope...
